### PR TITLE
Feature/query

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,9 @@
+rules = [
+    OrganizeImports
+]
+OrganizeImports {
+    expandRelative = true
+    groupedImports = Merge
+}
+OrganizeImports.targetDialect = Scala3
+OrganizeImports.removeUnused = true

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,14 +1,25 @@
-version = "3.7.15"
+version = "3.8.0"
+runner.dialect = scala3
+
 align.preset = most
+docstrings.style = Asterisk
 includeNoParensInSelectChains = true
 indent.main = 4
 indent.callSite = 4
-maxColumn = 100
+# Recommended, to not penalize `match` statements
+# indent.matchSite = 0
+maxColumn = 120
 newlines.alwaysBeforeElseAfterCurlyIf = true
+
 rewrite.rules = [
   PreferCurlyFors,
-  RedundantParens, 
+  RedundantParens,
   SortModifiers,
-  SortImports
+  Imports
 ]
-runner.dialect = scala3
+
+rewrite.imports.expand = false
+rewrite.imports.sort = original
+rewrite.scala3.convertToNewSyntax = true
+# rewrite.scala3.insertEndMarkerMinLines = 5
+rewrite.scala3.removeOptionalBraces = yes

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.7.14"
+version = "3.7.15"
 align.preset = most
 includeNoParensInSelectChains = true
 indent.main = 4

--- a/annosaurus/src/main/resources/reference.conf
+++ b/annosaurus/src/main/resources/reference.conf
@@ -48,6 +48,9 @@ database {
   url = ${?DATABASE_URL}
   user = "sa"
   user = ${?DATABASE_USER}
+
+  query.view = ${?DATABASE_QUERY_VIEW}
+  query.view = "annotations"
   # name = "Derby"
   # name = ${?DATABASE_NAME}
   # https://docs.jboss.org/hibernate/orm/4.3/manual/en-US/html_single/#configuration-optional-dialects

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
@@ -73,6 +73,7 @@ object AppConfig {
         user = Config.getString("database.user"),
         password = Config.getString("database.password"),
         driver = Config.getString("database.driver"),
+        queryView = Config.getString("database.query.view")
     )
 }
 
@@ -87,7 +88,8 @@ case class DatabaseConfig(
     url: String,
     user: String,
     password: String,
-    driver: String
+    driver: String,
+    queryView: String
 ):
     def newConnection(): java.sql.Connection =
         Class.forName(driver)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
@@ -24,16 +24,15 @@ import org.mbari.annosaurus.etc.jwt.JwtService
 import scala.util.Try
 import scala.util.control.NonFatal
 
-object AppConfig {
+object AppConfig:
 
     private val log = Logging(getClass)
 
     val Name: String = "annosaurus"
 
-    val Version: String = {
+    val Version: String =
         val v = Try(getClass.getPackage.getImplementationVersion).getOrElse("0.0.0")
-        if (v == null) "0.0.0" else v
-    }
+        if v == null then "0.0.0" else v
 
     val Description: String = "Annotation Service"
 
@@ -56,17 +55,15 @@ object AppConfig {
     )
 
     lazy val DefaultZeroMQConfig: Option[ZeroMQConfig] =
-        try {
+        try
             val port   = Config.getInt("messaging.zeromq.port")
             val enable = Config.getBoolean("messaging.zeromq.enable")
             val topic  = Config.getString("messaging.zeromq.topic")
             Some(ZeroMQConfig(port, enable, topic))
-        }
-        catch {
+        catch
             case NonFatal(e) =>
                 log.atWarn.withCause(e).log("Failed to load ZeroMQ configuration")
                 None
-        }
 
     lazy val DefaultDatabaseConfig: DatabaseConfig = DatabaseConfig(
         url = Config.getString("database.url"),
@@ -75,7 +72,6 @@ object AppConfig {
         driver = Config.getString("database.driver"),
         queryView = Config.getString("database.query.view")
     )
-}
 
 case class HttpConfig(
     port: Int,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
@@ -67,6 +67,13 @@ object AppConfig {
                 log.atWarn.withCause(e).log("Failed to load ZeroMQ configuration")
                 None
         }
+
+    lazy val DefaultDatabaseConfig: DatabaseConfig = DatabaseConfig(
+        url = Config.getString("database.url"),
+        user = Config.getString("database.user"),
+        password = Config.getString("database.password"),
+        driver = Config.getString("database.driver"),
+    )
 }
 
 case class HttpConfig(
@@ -75,3 +82,13 @@ case class HttpConfig(
     connectorIdleTimeout: Int,
     contextPath: String
 )
+
+case class DatabaseConfig(
+    url: String,
+    user: String,
+    password: String,
+    driver: String
+):
+    def newConnection(): java.sql.Connection =
+        Class.forName(driver)
+        java.sql.DriverManager.getConnection(url, user, password)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
@@ -17,8 +17,8 @@
 package org.mbari.annosaurus
 
 import com.typesafe.config.ConfigFactory
-import org.mbari.annosaurus.etc.jdk.Logging
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+import org.mbari.annosaurus.etc.jdk.Loggers
+import org.mbari.annosaurus.etc.jdk.Loggers.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
 
 import scala.util.Try
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 
 object AppConfig:
 
-    private val log = Logging(getClass)
+    private val log = Loggers(getClass)
 
     val Name: String = "annosaurus"
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
@@ -87,7 +87,7 @@ case class DatabaseConfig(
     driver: String,
     queryView: String
 ):
-    lazy val dataSource = {
+    lazy val dataSource                      =
         val ds = new com.zaxxer.hikari.HikariDataSource()
         ds.setJdbcUrl(url)
         ds.setUsername(user)
@@ -95,7 +95,6 @@ case class DatabaseConfig(
         ds.setDriverClassName(driver)
         ds.setMaximumPoolSize(AppConfig.NumberOfVertxWorkers)
         ds
-    }
     def newConnection(): java.sql.Connection =
         dataSource.getConnection()
         // Class.forName(driver)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/AppConfig.scala
@@ -87,6 +87,16 @@ case class DatabaseConfig(
     driver: String,
     queryView: String
 ):
+    lazy val dataSource = {
+        val ds = new com.zaxxer.hikari.HikariDataSource()
+        ds.setJdbcUrl(url)
+        ds.setUsername(user)
+        ds.setPassword(password)
+        ds.setDriverClassName(driver)
+        ds.setMaximumPoolSize(AppConfig.NumberOfVertxWorkers)
+        ds
+    }
     def newConnection(): java.sql.Connection =
-        Class.forName(driver)
-        java.sql.DriverManager.getConnection(url, user, password)
+        dataSource.getConnection()
+        // Class.forName(driver)
+        // java.sql.DriverManager.getConnection(url, user, password)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/Endpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/Endpoints.scala
@@ -44,6 +44,10 @@ object Endpoints {
     val imageReferenceController           = new ImageReferenceController(daoFactory)
     val indexController                    = new IndexController(daoFactory)
     val observationController              = new ObservationController(daoFactory)
+    val queryController                    = new QueryController(
+        AppConfig.DefaultDatabaseConfig,
+        AppConfig.DefaultDatabaseConfig.queryView
+    )
 
     // --------------------------------
     val analysisRepository = new AnalysisRepository(daoFactory.entityManagerFactory)
@@ -67,6 +71,7 @@ object Endpoints {
     val imageReferenceEndpoints           = new ImageReferenceEndpoints(imageReferenceController)
     val indexEndpoints                    = new IndexEndpoints(indexController)
     val observationEndpoints              = new ObservationEndpoints(observationController, jdbcRepository)
+    val queryEndpoints                    = new QueryEndpoints(queryController)
 
     // --------------------------------
     // For VertX, we need to separate the non-blocking endpoints from the blocking ones
@@ -86,7 +91,8 @@ object Endpoints {
         imageEndpoints.allImpl,
         imageReferenceEndpoints.allImpl,
         indexEndpoints.allImpl,
-        observationEndpoints.allImpl
+        observationEndpoints.allImpl,
+        queryEndpoints.allImpl
     ).flatten
 
     val apiEndpoints = nonBlockingEndpoints ++ blockingEndpoints

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/Endpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/Endpoints.scala
@@ -27,7 +27,7 @@ import sttp.tapir.swagger.bundle.SwaggerInterpreter
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object Endpoints {
+object Endpoints:
 
     // --------------------------------
     given ExecutionContext = ExecutionContext.global
@@ -119,5 +119,3 @@ object Endpoints {
 
     val all: List[ServerEndpoint[Any, Future]] =
         apiEndpoints ++ docEndpoints ++ List(metricsEndpoint)
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/Main.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/Main.scala
@@ -18,8 +18,8 @@ package org.mbari.annosaurus
 
 import io.vertx.core.{Vertx, VertxOptions}
 import io.vertx.ext.web.Router
-import org.mbari.annosaurus.etc.jdk.Logging
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 import org.mbari.annosaurus.etc.zeromq.ZeroMQPublisher
 import sttp.tapir.server.vertx.VertxFutureServerInterpreter.VertxFutureToScalaFuture
 import sttp.tapir.server.vertx.{VertxFutureServerInterpreter, VertxFutureServerOptions}
@@ -31,7 +31,7 @@ object Main:
 
     // hold on to messaging objects so they don't get GC'd
     private val zmq = ZeroMQPublisher.autowire(AppConfig.DefaultZeroMQConfig)
-    private val log = Logging(this.getClass)
+    private val log = Loggers(this.getClass)
 
     def main(args: Array[String]): Unit =
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/Main.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/Main.scala
@@ -19,14 +19,13 @@ package org.mbari.annosaurus
 import io.vertx.core.{Vertx, VertxOptions}
 import io.vertx.ext.web.Router
 import org.mbari.annosaurus.etc.jdk.Logging
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+import org.mbari.annosaurus.etc.jdk.Logging.given
 import org.mbari.annosaurus.etc.zeromq.ZeroMQPublisher
-import sttp.tapir.server.vertx.{VertxFutureServerInterpreter, VertxFutureServerOptions}
 import sttp.tapir.server.vertx.VertxFutureServerInterpreter.VertxFutureToScalaFuture
+import sttp.tapir.server.vertx.{VertxFutureServerInterpreter, VertxFutureServerOptions}
 
-import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
-import scala.io.StdIn
+import scala.concurrent.{Await, ExecutionContext}
 
 object Main:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/Main.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/Main.scala
@@ -63,7 +63,8 @@ object Main:
         val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
         log.atInfo.log(s"Starting ${AppConfig.Name} v${AppConfig.Version} on port $port")
 
-        val vertx  = Vertx.vertx(new VertxOptions().setWorkerPoolSize(AppConfig.NumberOfVertxWorkers))
+        val vertx  =
+            Vertx.vertx(new VertxOptions().setWorkerPoolSize(AppConfig.NumberOfVertxWorkers))
 //        val vertx  = Vertx.vertx()
         val server = vertx.createHttpServer()
         val router = Router.router(vertx)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/PersistentObject.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/PersistentObject.scala
@@ -18,15 +18,14 @@ package org.mbari.annosaurus
 
 import java.util.UUID
 
-/** We have made a design decision to always use UUIDs (aka GUIDs) as the primary key. This
-  * requirement is enforced so that external applications can rely on the use of that key. All
-  * persistent objects should implement this trait
-  *
-  * @author
-  *   Brian Schlining
-  * @since 2016-05-05T16:21:00
-  */
-trait PersistentObject {
+/**
+ * We have made a design decision to always use UUIDs (aka GUIDs) as the primary key. This requirement is enforced so
+ * that external applications can rely on the use of that key. All persistent objects should implement this trait
+ *
+ * @author
+ *   Brian Schlining
+ * @since 2016-05-05T16:21:00
+ */
+trait PersistentObject:
 
     def primaryKey: Option[UUID]
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/annosaurus.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/annosaurus.scala
@@ -16,8 +16,9 @@
 
 package org.mbari
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-15T16:50:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-15T16:50:00
+ */
 package object annosaurus {}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AnnotationController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AnnotationController.scala
@@ -18,7 +18,7 @@ package org.mbari.annosaurus.controllers
 
 import io.reactivex.rxjava3.subjects.Subject
 import org.mbari.annosaurus.domain.{Annotation, ConcurrentRequest, ImageCreateSC, MultiRequest}
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 import org.mbari.annosaurus.messaging.{AnnotationPublisher, MessageBus}
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.repository.jpa.entity.{ImagedMomentEntity, ObservationEntity}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AnnotationController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AnnotationController.scala
@@ -249,7 +249,7 @@ class AnnotationController(
 
     def create(annotation: Annotation)(using ec: ExecutionContext): Future[Seq[Annotation]] =
         val entity = annotation.toEntity
-        val dao = daoFactory.newImagedMomentDAO()
+        val dao    = daoFactory.newImagedMomentDAO()
         val future = dao.runTransaction(d => {
 //            d.create(entity)
 //            Annotation.fromImagedMoment(entity, true)
@@ -258,7 +258,6 @@ class AnnotationController(
         })
         future.onComplete(_ => dao.close())
         future
-
 
     /** Bulk create annotations
       * @param annotations

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AnnotationController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AnnotationController.scala
@@ -525,8 +525,7 @@ class AnnotationController(
                             .getImageReferences
                             .isEmpty
                     then imDao.delete(imagedMoment)
-                    else
-                        imagedMoment.removeObservation(v)
+                    else imagedMoment.removeObservation(v)
 //                        d.delete(v)
                     true
         )

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AnnotationController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AnnotationController.scala
@@ -42,14 +42,15 @@ import org.mbari.annosaurus.etc.sdk.Futures.*
 
 import scala.util.chaining.*
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-25T20:28:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-25T20:28:00
+ */
 class AnnotationController(
     val daoFactory: JPADAOFactory,
     bus: Subject[Any] = MessageBus.RxSubject
-) {
+):
 
     private val imagedMomentController = new ImagedMomentController(daoFactory)
     private val annotationPublisher    = new AnnotationPublisher(bus)
@@ -57,28 +58,24 @@ class AnnotationController(
 
     protected def exec[T](
         fn: ObservationDAO[ObservationEntity] => T
-    )(implicit ec: ExecutionContext): Future[T] = {
+    )(implicit ec: ExecutionContext): Future[T] =
         val dao = daoFactory.newObservationDAO()
         val f   = dao.runTransaction(fn)
         f.onComplete(_ => dao.close())
         f
-    }
 
-    def findByUUID(uuid: UUID)(implicit ec: ExecutionContext): Future[Option[Annotation]] = {
+    def findByUUID(uuid: UUID)(implicit ec: ExecutionContext): Future[Option[Annotation]] =
         // val obsDao = daoFactory.newObservationDAO()
         // val f      = obsDao.runTransaction(d => obsDao.findByUUID(uuid))
         // f.onComplete(_ => obsDao.close())
         // f.map(_.map(obs => Annotation.from(obs, true)))
         exec(d => d.findByUUID(uuid).map(Annotation.from(_, true)))
 
-    }
-
-    def countByVideoReferenceUuid(uuid: UUID)(implicit ec: ExecutionContext): Future[Int] = {
+    def countByVideoReferenceUuid(uuid: UUID)(implicit ec: ExecutionContext): Future[Int] =
         val dao = daoFactory.newObservationDAO()
         val f   = dao.runTransaction(d => d.countByVideoReferenceUUID(uuid))
         f.onComplete(_ => dao.close())
         f
-    }
 
     /*
       This searches for the ImagedMoments but returns an MutableAnnotation view. Keep in mind
@@ -92,7 +89,7 @@ class AnnotationController(
         limit: Option[Int] = None,
         offset: Option[Int] = None,
         includedAncillaryData: Boolean = false
-    )(implicit ec: ExecutionContext): Future[Seq[Annotation]] = {
+    )(implicit ec: ExecutionContext): Future[Seq[Annotation]] =
 
         val dao = daoFactory.newObservationDAO()
         val f   =
@@ -104,20 +101,19 @@ class AnnotationController(
         f.onComplete(_ => dao.close())
         f
         // f.map(_.map(obs => Annotation.from(obs, true)).toSeq)
-    }
 
-    /** @param videoReferenceUuid
-      * @param limit
-      * @param offset
-      * @return
-      *   A butple of a closeable, and a stream. When the stream is done being processed invoke the
-      *   closeable
-      */
+    /**
+     * @param videoReferenceUuid
+     * @param limit
+     * @param offset
+     * @return
+     *   A butple of a closeable, and a stream. When the stream is done being processed invoke the closeable
+     */
     def streamByVideoReferenceUUID(
         videoReferenceUuid: UUID,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    ): (Closeable, java.util.stream.Stream[Annotation]) = {
+    ): (Closeable, java.util.stream.Stream[Annotation]) =
         val dao = daoFactory.newObservationDAO()
         (
             () => dao.close(),
@@ -125,7 +121,6 @@ class AnnotationController(
                 .streamByVideoReferenceUUID(videoReferenceUuid, limit, offset)
                 .map(obs => Annotation.from(obs, true))
         )
-    }
 
     def streamByVideoReferenceUUIDAndTimestamps(
         videoReferenceUuid: UUID,
@@ -133,7 +128,7 @@ class AnnotationController(
         endTimestamp: Instant,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    ): (Closeable, java.util.stream.Stream[Annotation]) = {
+    ): (Closeable, java.util.stream.Stream[Annotation]) =
 //    val dao = daoFactory.newImagedMomentDAO()
 //    (() => dao.close(),
 //      dao.streamByVideoReferenceUUIDAndTimestamps(videoReferenceUuid, startTimestamp, endTimestamp, limit, offset)
@@ -151,52 +146,47 @@ class AnnotationController(
                 )
                 .map(obs => Annotation.from(obs, true))
         )
-    }
 
     def streamByConcurrentRequest(
         request: ConcurrentRequest,
         limit: Option[Int],
         offset: Option[Int]
-    ): (Closeable, java.util.stream.Stream[Annotation]) = {
+    ): (Closeable, java.util.stream.Stream[Annotation]) =
         val dao = daoFactory.newObservationDAO()
         (
             () => dao.close(),
             dao.streamByConcurrentRequest(request, limit, offset)
                 .map(obs => Annotation.from(obs, true))
         )
-    }
 
     def countByConcurrentRequest(
         request: ConcurrentRequest
-    )(implicit ec: ExecutionContext): Future[Long] = {
+    )(implicit ec: ExecutionContext): Future[Long] =
         def dao = daoFactory.newObservationDAO()
         val f   = dao.runTransaction(d => d.countByConcurrentRequest(request))
         f.onComplete(t => dao.close())
         f
-    }
 
     def streamByMultiRequest(
         request: MultiRequest,
         limit: Option[Int],
         offset: Option[Int]
-    ): (Closeable, java.util.stream.Stream[Annotation]) = {
+    ): (Closeable, java.util.stream.Stream[Annotation]) =
         val dao = daoFactory.newObservationDAO()
         (
             () => dao.close(),
             dao.streamByMultiRequest(request, limit, offset).map(obs => Annotation.from(obs))
         )
-    }
 
-    def countByMultiRequest(request: MultiRequest)(implicit ec: ExecutionContext): Future[Long] = {
+    def countByMultiRequest(request: MultiRequest)(implicit ec: ExecutionContext): Future[Long] =
         def dao = daoFactory.newObservationDAO()
         val f   = dao.runTransaction(d => d.countByMultiRequest(request))
         f.onComplete(t => dao.close())
         f
-    }
 
     def findByImageReferenceUUID(
         imageReferenceUUID: UUID
-    )(implicit ec: ExecutionContext): Future[Iterable[Annotation]] = {
+    )(implicit ec: ExecutionContext): Future[Iterable[Annotation]] =
 
         val imDao = daoFactory.newImagedMomentDAO()
         val f     = imDao.runTransaction(d =>
@@ -206,7 +196,6 @@ class AnnotationController(
         )
         f.onComplete(t => imDao.close())
         f
-    }
 
     def create(
         videoReferenceUUID: UUID,
@@ -219,7 +208,7 @@ class AnnotationController(
         duration: Option[Duration] = None,
         group: Option[String] = None,
         activity: Option[String] = None
-    )(implicit ec: ExecutionContext): Future[Annotation] = {
+    )(implicit ec: ExecutionContext): Future[Annotation] =
         // We need to assign a UUID first so that we can find the correct
         // observation. This is only needed if more than one observation
         // exists at the same timestamp
@@ -245,34 +234,33 @@ class AnnotationController(
                         && a.observationTimestamp.orNull == observationDate
                 ).orNull
             )
-    }
 
     def create(annotation: Annotation)(using ec: ExecutionContext): Future[Seq[Annotation]] =
         val entity = annotation.toEntity
         val dao    = daoFactory.newImagedMomentDAO()
-        val future = dao.runTransaction(d => {
+        val future = dao.runTransaction(d =>
 //            d.create(entity)
 //            Annotation.fromImagedMoment(entity, true)
             val newIm = imagedMomentController.create(d, entity)
             Annotation.fromImagedMoment(newIm, true)
-        })
+        )
         future.onComplete(_ => dao.close())
         future
 
-    /** Bulk create annotations
-      * @param annotations
-      *   THe annotations to create
-      * @return
-      *   The newly created annotations along with any existing ones that share the same
-      *   imagedMoment
-      */
+    /**
+     * Bulk create annotations
+     * @param annotations
+     *   THe annotations to create
+     * @return
+     *   The newly created annotations along with any existing ones that share the same imagedMoment
+     */
     def bulkCreate(
         annotations: Iterable[Annotation]
-    )(using ec: ExecutionContext): Future[Seq[Annotation]] = {
+    )(using ec: ExecutionContext): Future[Seq[Annotation]] =
 
         // short circuit if there ore 0 or 1 annotations
-        if (annotations.isEmpty) return Future.successful(Nil)
-        else if (annotations.size == 1) return create(annotations.head)
+        if annotations.isEmpty then return Future.successful(Nil)
+        else if annotations.size == 1 then return create(annotations.head)
 
         val obsDao          = daoFactory.newObservationDAO()
         val imDao           = daoFactory.newImagedMomentDAO(obsDao)
@@ -292,22 +280,21 @@ class AnnotationController(
             images               <- imageController.bulkCreate(imageCreates)
             persistedAnnotations <-
                 obsDao
-                    .runTransaction(d => {
+                    .runTransaction(d =>
                         for im <- imagedMoments
                         yield
                             val newIm = imagedMomentController.create(d, im)
                             Annotation.fromImagedMoment(newIm, true)
-                    })
+                    )
         yield persistedAnnotations.flatten
 
         future.onComplete(_ => obsDao.close())
         future.foreach(annotationPublisher.publish) // publish new annotations
         future
-    }
 
     def update(observationUuid: UUID, annotation: Annotation)(implicit
         ec: ExecutionContext
-    ): Future[Option[Annotation]] = {
+    ): Future[Option[Annotation]] =
         update(
             observationUuid,
             annotation.videoReferenceUuid,
@@ -321,7 +308,6 @@ class AnnotationController(
             annotation.group,
             annotation.activity
         )
-    }
 
     def update(
         uuid: UUID,
@@ -335,7 +321,7 @@ class AnnotationController(
         duration: Option[Duration] = None,
         group: Option[String] = None,
         activity: Option[String] = None
-    )(implicit ec: ExecutionContext): Future[Option[Annotation]] = {
+    )(implicit ec: ExecutionContext): Future[Option[Annotation]] =
 
         // We have to do this in 2 transactions. The first makes all the changes. The second to
         // retrieve them. We have to do this because we may make a SQL call to move an observaton
@@ -360,21 +346,20 @@ class AnnotationController(
         )
         f.onComplete(_ => dao.close())
 
-        val g = f.flatMap(opt => {
+        val g = f.flatMap(opt =>
             val dao1 = daoFactory.newObservationDAO()
             val ff   = dao1.runTransaction(d => d.findByUUID(uuid).map(Annotation.from(_, true)))
             ff.onComplete(_ => dao1.close())
             ff
-        })
+        )
 
         g.foreach(annotationPublisher.publish)
 
         g
-    }
 
     def bulkUpdate(
         annotations: Iterable[Annotation]
-    )(implicit ec: ExecutionContext): Future[Iterable[Annotation]] = {
+    )(implicit ec: ExecutionContext): Future[Iterable[Annotation]] =
 
         val goodAnnos = annotations.filter(x => x.observationUuid.isDefined)
 
@@ -383,8 +368,8 @@ class AnnotationController(
         // to a new imagedmoment. The enitymanage doesn't see this change and so returns the cached
         // value which may have the wrong time index or videoreference.
         val dao = daoFactory.newObservationDAO()
-        val f   = dao.runTransaction(d => {
-            goodAnnos.flatMap(a => {
+        val f   = dao.runTransaction(d =>
+            goodAnnos.flatMap(a =>
                 _update(
                     d,
                     a.observationUuid.get,
@@ -399,104 +384,92 @@ class AnnotationController(
                     a.group,
                     a.activity
                 )
-            })
-        })
+            )
+        )
 
         // --- After update find all the changes
-        val h = f.flatMap(obs => {
+        val h = f.flatMap(obs =>
             val dao1 = daoFactory.newObservationDAO()
-            val ff   = dao.runTransaction(d =>
-                obs.flatMap(o => d.findByUUID(o.getUuid).map(Annotation.from(_, true)))
-            )
+            val ff   = dao.runTransaction(d => obs.flatMap(o => d.findByUUID(o.getUuid).map(Annotation.from(_, true))))
             ff.onComplete(_ => dao1.close())
             ff
-        })
+        )
         h
-    }
 
     def bulkUpdateRecordedTimestampOnly(
         annotations: Iterable[Annotation]
-    )(implicit ec: ExecutionContext): Future[Iterable[Annotation]] = {
-        if (annotations.isEmpty) Future.successful(Nil)
+    )(implicit ec: ExecutionContext): Future[Iterable[Annotation]] =
+        if annotations.isEmpty then Future.successful(Nil)
         else
             val goodAnnos = annotations.filter(x => x.observationUuid.isDefined)
             val dao       = daoFactory.newObservationDAO()
-            val f         = dao.runTransaction(d => {
-                goodAnnos.flatMap(a => {
-                    _updateRecordedTimestamp(d, a.observationUuid.get, a.recordedTimestamp)
-                })
-            })
+            val f         = dao.runTransaction(d =>
+                goodAnnos.flatMap(a => _updateRecordedTimestamp(d, a.observationUuid.get, a.recordedTimestamp))
+            )
             f.onComplete(_ => dao.close())
             // --- After update find all the changes
-            val g         = f.flatMap(obs => {
+            val g         = f.flatMap(obs =>
                 val dao1 = daoFactory.newObservationDAO()
                 val ff   =
-                    dao1.runTransaction(d =>
-                        obs.flatMap(o => d.findByUUID(o.getUuid).map(Annotation.from(_, true)))
-                    )
+                    dao1.runTransaction(d => obs.flatMap(o => d.findByUUID(o.getUuid).map(Annotation.from(_, true))))
                 ff.onComplete(_ => dao1.close())
                 ff
-            })
+            )
             g
-    }
 
-    /** This is a special method to handle the case where an ImagedMoment's recordedTimestamp needs
-      * to be explicity changed and NOT moved. It is meant for tape annotations where the timecode
-      * is the correct index and the recordedTimestamp may need to be adjusted in-place
-      * @param dao
-      * @param uuid
-      * @param recordedTimestampOpt
-      * @return
-      *   Observations that belong to the imagedmoment that was modified
-      */
+    /**
+     * This is a special method to handle the case where an ImagedMoment's recordedTimestamp needs to be explicity
+     * changed and NOT moved. It is meant for tape annotations where the timecode is the correct index and the
+     * recordedTimestamp may need to be adjusted in-place
+     * @param dao
+     * @param uuid
+     * @param recordedTimestampOpt
+     * @return
+     *   Observations that belong to the imagedmoment that was modified
+     */
     private def _updateRecordedTimestamp(
         dao: DAO[?],
         uuid: UUID,
         recordedTimestampOpt: Option[Instant]
-    ): Seq[ObservationEntity] = {
+    ): Seq[ObservationEntity] =
 
         val obsDao = daoFactory.newObservationDAO(dao)
         obsDao
             .findByUUID(uuid)
-            .map(observation => {
+            .map(observation =>
                 val imagedMoment        = observation.getImagedMoment
                 val timecodeOpt         = Option(imagedMoment.getTimecode)
                 val currentTimestampOpt = Option(imagedMoment.getRecordedTimestamp)
                 // MUST have a timecode!! This method is for tape annotations
-                if (timecodeOpt.isEmpty) Nil
-                else if (recordedTimestampOpt.isEmpty && currentTimestampOpt.isDefined) {
+                if timecodeOpt.isEmpty then Nil
+                else if recordedTimestampOpt.isEmpty && currentTimestampOpt.isDefined then
                     imagedMoment.setRecordedTimestamp(null)
                     imagedMoment.getObservations.asScala.toSeq
-                }
-                else if (
-                    recordedTimestampOpt.isDefined
+                else if recordedTimestampOpt.isDefined
                     && (currentTimestampOpt.isEmpty || currentTimestampOpt.get != recordedTimestampOpt.get)
-                ) {
+                then
                     recordedTimestampOpt.foreach(imagedMoment.setRecordedTimestamp)
                     imagedMoment.getObservations.asScala.toSeq
-                }
                 else Nil
-            })
+            )
             .getOrElse(Nil)
 
-    }
-
-    /** This private method is meant to be wrapped in a transaction, either for a single update or
-      * for bulk updates
-      * @param dao
-      * @param uuid
-      * @param videoReferenceUUID
-      * @param concept
-      * @param observer
-      * @param observationDate
-      * @param timecode
-      * @param elapsedTime
-      * @param recordedDate
-      * @param duration
-      * @param group
-      * @param activity
-      * @return
-      */
+    /**
+     * This private method is meant to be wrapped in a transaction, either for a single update or for bulk updates
+     * @param dao
+     * @param uuid
+     * @param videoReferenceUUID
+     * @param concept
+     * @param observer
+     * @param observationDate
+     * @param timecode
+     * @param elapsedTime
+     * @param recordedDate
+     * @param duration
+     * @param group
+     * @param activity
+     * @return
+     */
     private def _update(
         dao: DAO[?],
         uuid: UUID,
@@ -510,11 +483,11 @@ class AnnotationController(
         duration: Option[Duration] = None,
         group: Option[String] = None,
         activity: Option[String] = None
-    ): Option[ObservationEntity] = {
+    ): Option[ObservationEntity] =
         val obsDao      = daoFactory.newObservationDAO(dao)
         val imDao       = daoFactory.newImagedMomentDAO(dao)
         val observation = obsDao.findByUUID(uuid)
-        observation.map(obs => {
+        observation.map(obs =>
 
             val imagedMoment = obs.getImagedMoment
 
@@ -525,7 +498,7 @@ class AnnotationController(
             val etSame = elapsedTime.contains(imagedMoment.getElapsedTime)
             val rtSame = recordedDate.contains(imagedMoment.getRecordedTimestamp)
 
-            if (!vrSame || !tcSame || !etSame || !rtSame) {
+            if !vrSame || !tcSame || !etSame || !rtSame then
                 val vrUUID = videoReferenceUUID.getOrElse(imagedMoment.getVideoReferenceUuid)
                 val tc     = Option(timecode.getOrElse(imagedMoment.getTimecode))
                 val rd     = Option(recordedDate.getOrElse(imagedMoment.getRecordedTimestamp))
@@ -533,13 +506,10 @@ class AnnotationController(
                 val newIm  =
                     ImagedMomentController.findOrCreateImagedMoment(imDao, vrUUID, tc, rd, et)
                 log.atDebug
-                    .log(() =>
-                        s"Moving observation ${obs.getUuid} to imagedMoment ${newIm.getUuid}"
-                    )
+                    .log(() => s"Moving observation ${obs.getUuid} to imagedMoment ${newIm.getUuid}")
                 imDao.update(imagedMoment)
 //                imagedMoment.removeObservation(obs) // This causes a delete which messes up the transaction as the observation becomes detached
                 newIm.addObservation(obs)
-            }
 
             concept.foreach(obs.setConcept)
             observer.foreach(obs.setObserver)
@@ -550,33 +520,24 @@ class AnnotationController(
 //            obsDao.update(obs)
             dao.flush()
             obs
-        })
-    }
+        )
 
-    def delete(uuid: UUID)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def delete(uuid: UUID)(implicit ec: ExecutionContext): Future[Boolean] =
         val imDao  = daoFactory.newImagedMomentDAO()
         val obsDao = daoFactory.newObservationDAO(imDao)
-        val f      = obsDao.runTransaction(d => {
-            d.findByUUID(uuid) match {
+        val f      = obsDao.runTransaction(d =>
+            d.findByUUID(uuid) match
                 case None    => false
                 case Some(v) =>
                     val imagedMoment = v.getImagedMoment
-                    if (
-                        imagedMoment.getObservations.size == 1 && imagedMoment
+                    if imagedMoment.getObservations.size == 1 && imagedMoment
                             .getImageReferences
                             .isEmpty
-                    ) {
-                        imDao.delete(imagedMoment)
-                    }
-                    else {
+                    then imDao.delete(imagedMoment)
+                    else
                         imagedMoment.removeObservation(v)
 //                        d.delete(v)
-                    }
                     true
-            }
-        })
+        )
         f.onComplete(_ => obsDao.close())
         f
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AnnotationController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AnnotationController.scala
@@ -16,30 +16,21 @@
 
 package org.mbari.annosaurus.controllers
 
+import io.reactivex.rxjava3.subjects.Subject
+import org.mbari.annosaurus.domain.{Annotation, ConcurrentRequest, ImageCreateSC, MultiRequest}
+import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.messaging.{AnnotationPublisher, MessageBus}
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import org.mbari.annosaurus.repository.jpa.entity.{ImagedMomentEntity, ObservationEntity}
+import org.mbari.annosaurus.repository.{DAO, ObservationDAO}
+import org.mbari.vcr4j.time.Timecode
+
 import java.io.Closeable
 import java.time.{Duration, Instant}
 import java.util.UUID
-import java.util.concurrent.Executors
-import io.reactivex.rxjava3.subjects.Subject
-import org.mbari.annosaurus.messaging.{AnnotationPublisher, MessageBus}
-import org.mbari.annosaurus.domain.{Annotation, ConcurrentRequest, ImageCreateSC, MultiRequest}
-import org.mbari.annosaurus.repository.DAO
-import org.mbari.annosaurus.repository.jpa.entity.{ImagedMomentEntity, ObservationEntity}
-import org.mbari.vcr4j.time.Timecode
-import org.mbari.annosaurus.repository.jpa.Implicits.*
-
-import scala.concurrent.{ExecutionContext, Future}
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
-import org.mbari.annosaurus.repository.ObservationDAO
-import org.mbari.annosaurus.etc.jdk.Logging.given
-
-import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-
 import scala.collection.mutable
-import org.mbari.annosaurus.etc.sdk.Futures.*
-
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters.*
 import scala.util.chaining.*
 
 /**

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AssociationController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AssociationController.scala
@@ -34,14 +34,15 @@ import org.mbari.annosaurus.domain.{
 }
 import org.checkerframework.checker.units.qual.t
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-07-09T15:51:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-07-09T15:51:00
+ */
 class AssociationController(
     val daoFactory: JPADAOFactory,
     bus: Subject[Any] = MessageBus.RxSubject
-) extends BaseController[AssociationEntity, AssociationDAO[AssociationEntity], Association] {
+) extends BaseController[AssociationEntity, AssociationDAO[AssociationEntity], Association]:
 
     type ADAO = AssociationDAO[AssociationEntity]
 
@@ -58,10 +59,10 @@ class AssociationController(
         linkValue: String,
         mimeType: String,
         associationUuid: Option[UUID] = None
-    )(implicit ec: ExecutionContext): Future[Association] = {
-        def fn(dao: ADAO): AssociationEntity = {
+    )(implicit ec: ExecutionContext): Future[Association] =
+        def fn(dao: ADAO): AssociationEntity =
             val obsDao = daoFactory.newObservationDAO(dao)
-            obsDao.findByUUID(observationUuid) match {
+            obsDao.findByUUID(observationUuid) match
                 case None              =>
                     throw new NotFoundInDatastoreException(
                         s"MutableObservation with UUID of $observationUuid not found"
@@ -77,14 +78,11 @@ class AssociationController(
                     associationUuid.foreach(association.setUuid)
                     observation.addAssociation(association)
                     association
-            }
-        }
-        exec(fn).map(entity => {
+        exec(fn).map(entity =>
             val a = transform(entity) // transform after transaction is committed or UUID isn't set
             associationPublisher.publish(a)
             a
-        })
-    }
+        )
 
     def update(
         uuid: UUID,
@@ -93,101 +91,88 @@ class AssociationController(
         toConcept: Option[String] = None,
         linkValue: Option[String] = None,
         mimeType: Option[String] = None
-    )(implicit ec: ExecutionContext): Future[Option[Association]] = {
+    )(implicit ec: ExecutionContext): Future[Option[Association]] =
 
-        def fn(dao: ADAO): Option[Association] = {
+        def fn(dao: ADAO): Option[Association] =
             dao
                 .findByUUID(uuid)
-                .map(association => {
+                .map(association =>
                     linkName.foreach(association.setLinkName)
                     toConcept.foreach(association.setToConcept)
                     linkValue.foreach(association.setLinkValue)
                     mimeType.foreach(association.setMimeType)
                     // Move to new observation if it exists
-                    for {
+                    for
                         obsUUID <- observationUUID
                         obsDao   = daoFactory.newObservationDAO(dao)
                         obs     <- obsDao.findByUUID(obsUUID)
-                    } {
+                    do
                         association.getObservation.removeAssociation(association)
                         obs.addAssociation(association)
-                    }
                     associationPublisher.publish(Association.from(association))
                     transform(association)
-                })
-        }
+                )
 
         exec(fn)
-    }
 
     def bulkUpdate(
         associations: Iterable[Association]
-    )(implicit ec: ExecutionContext): Future[Iterable[Association]] = {
+    )(implicit ec: ExecutionContext): Future[Iterable[Association]] =
         def fn(dao: ADAO): Iterable[Association] =
             val validAssociations = associations.filter(_.uuid.isDefined)
-            validAssociations.flatMap(a0 => {
+            validAssociations.flatMap(a0 =>
                 dao
                     .findByUUID(a0.uuid.get)
-                    .map(a1 => {
+                    .map(a1 =>
                         a1.setLinkName(a0.linkName)
                         a1.setToConcept(a0.toConcept)
                         a1.setLinkValue(a0.linkValue)
                         a0.mimeType.foreach(a1.setMimeType)
                         transform(a1)
-                    })
-            })
+                    )
+            )
         exec(fn)
-    }
 
-    def bulkDelete(uuids: Iterable[UUID])(implicit ec: ExecutionContext): Future[Unit] = {
+    def bulkDelete(uuids: Iterable[UUID])(implicit ec: ExecutionContext): Future[Unit] =
         def fn(dao: ADAO): Unit = uuids.foreach(uuid => dao.deleteByUUID(uuid))
         exec(fn)
-    }
 
     def findByLinkName(
         linkName: String
-    )(implicit ec: ExecutionContext): Future[Iterable[Association]] = {
+    )(implicit ec: ExecutionContext): Future[Iterable[Association]] =
         def fn(dao: ADAO): Iterable[Association] = dao.findByLinkName(linkName).map(transform)
         exec(fn)
-    }
 
     def findByLinkNameAndVideoReferenceUuid(linkName: String, videoReferenceUUID: UUID)(implicit
         ec: ExecutionContext
-    ): Future[Iterable[Association]] = {
+    ): Future[Iterable[Association]] =
         def fn(dao: ADAO): Iterable[Association] =
             dao.findByLinkNameAndVideoReferenceUUID(linkName, videoReferenceUUID).map(transform)
         exec(fn)
-    }
 
     def findByLinkNameAndVideoReferenceUuidAndConcept(
         linkName: String,
         videoReferenceUUID: UUID,
         concept: Option[String] = None
-    )(implicit ec: ExecutionContext): Future[Iterable[Association]] = {
+    )(implicit ec: ExecutionContext): Future[Iterable[Association]] =
         def fn(dao: ADAO): Iterable[Association] =
             dao.findByLinkNameAndVideoReferenceUUIDAndConcept(linkName, videoReferenceUUID, concept)
                 .map(transform)
         exec(fn)
-    }
 
     def findByConceptAssociationRequest(
         request: ConceptAssociationRequest
-    )(implicit ec: ExecutionContext): Future[ConceptAssociationResponse] = {
+    )(implicit ec: ExecutionContext): Future[ConceptAssociationResponse] =
         def fn(dao: ADAO): Iterable[ConceptAssociation] =
             dao.findByConceptAssociationRequest(request)
         exec(fn).map(ca => ConceptAssociationResponse(request, ca.toSeq))
-    }
 
-    def countByToConcept(concept: String)(implicit ec: ExecutionContext): Future[Long] = {
+    def countByToConcept(concept: String)(implicit ec: ExecutionContext): Future[Long] =
         def fn(dao: ADAO): Long = dao.countByToConcept(concept)
         exec(fn)
-    }
 
     def updateToConcept(oldToConcept: String, newToConcept: String)(implicit
         ec: ExecutionContext
-    ): Future[Int] = {
+    ): Future[Int] =
         def fn(dao: ADAO): Int = dao.updateToConcept(oldToConcept, newToConcept)
         exec(fn)
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AssociationController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/AssociationController.scala
@@ -16,23 +16,20 @@
 
 package org.mbari.annosaurus.controllers
 
-import java.util.UUID
-
 import io.reactivex.rxjava3.subjects.Subject
-import org.mbari.annosaurus.messaging.{AssociationPublisher, MessageBus}
-
-import org.mbari.annosaurus.repository.{AssociationDAO, NotFoundInDatastoreException}
-
-import scala.concurrent.{ExecutionContext, Future}
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.repository.jpa.entity.AssociationEntity
 import org.mbari.annosaurus.domain.{
     Association,
     ConceptAssociation,
     ConceptAssociationRequest,
     ConceptAssociationResponse
 }
-import org.checkerframework.checker.units.qual.t
+import org.mbari.annosaurus.messaging.{AssociationPublisher, MessageBus}
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import org.mbari.annosaurus.repository.jpa.entity.AssociationEntity
+import org.mbari.annosaurus.repository.{AssociationDAO, NotFoundInDatastoreException}
+
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/BaseController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/BaseController.scala
@@ -16,13 +16,12 @@
 
 package org.mbari.annosaurus.controllers
 
-import org.mbari.annosaurus.PersistentObject
 import org.mbari.annosaurus.repository.DAO
-import java.util.UUID
-
-import scala.concurrent.{ExecutionContext, Future}
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
+
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/BaseController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/BaseController.scala
@@ -24,11 +24,12 @@ import scala.concurrent.{ExecutionContext, Future}
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-25T17:17:00
-  */
-trait BaseController[A <: IPersistentObject, B <: DAO[A], C] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-25T17:17:00
+ */
+trait BaseController[A <: IPersistentObject, B <: DAO[A], C]:
 
     def daoFactory: JPADAOFactory
 
@@ -36,25 +37,21 @@ trait BaseController[A <: IPersistentObject, B <: DAO[A], C] {
 
     def transform(a: A): C
 
-    protected def exec[T](fn: B => T)(implicit ec: ExecutionContext): Future[T] = {
+    protected def exec[T](fn: B => T)(implicit ec: ExecutionContext): Future[T] =
         val dao = newDAO()
         val f   = dao.runTransaction(fn)
         f.onComplete(_ => dao.close())
         f
-    }
 
-    def delete(uuid: UUID)(implicit ec: ExecutionContext): Future[Boolean] = {
-        def fn(dao: B): Boolean = {
-            dao.findByUUID(uuid) match {
+    def delete(uuid: UUID)(implicit ec: ExecutionContext): Future[Boolean] =
+        def fn(dao: B): Boolean =
+            dao.findByUUID(uuid) match
                 case Some(v) =>
                     dao.delete(v)
                     true
                 case None    =>
                     false
-            }
-        }
         exec(fn)
-    }
 
     def findAll(limit: Option[Int] = None, offset: Option[Int] = None)(implicit
         ec: ExecutionContext
@@ -63,5 +60,3 @@ trait BaseController[A <: IPersistentObject, B <: DAO[A], C] {
 
     def findByUUID(uuid: UUID)(implicit ec: ExecutionContext): Future[Option[C]] =
         exec(d => d.findByUUID(uuid).map(transform))
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumController.scala
@@ -17,7 +17,7 @@
 package org.mbari.annosaurus.controllers
 
 import org.mbari.annosaurus.domain.CachedAncillaryDatum
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 import org.mbari.annosaurus.repository.jpa.entity.{CachedAncillaryDatumEntity, ImagedMomentEntity}
 import org.mbari.annosaurus.repository.jpa.{BaseDAO, JPADAOFactory}
 import org.mbari.annosaurus.repository.{CachedAncillaryDatumDAO, NotFoundInDatastoreException}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumController.scala
@@ -16,20 +16,16 @@
 
 package org.mbari.annosaurus.controllers
 
+import org.mbari.annosaurus.domain.CachedAncillaryDatum
+import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.repository.jpa.entity.{CachedAncillaryDatumEntity, ImagedMomentEntity}
+import org.mbari.annosaurus.repository.jpa.{BaseDAO, JPADAOFactory}
+import org.mbari.annosaurus.repository.{CachedAncillaryDatumDAO, NotFoundInDatastoreException}
 import org.mbari.annosaurus.util.FastCollator
+
 import java.time.Duration
 import java.util.UUID
-
-import org.mbari.annosaurus.repository.jpa.BaseDAO
-import org.mbari.annosaurus.repository.{CachedAncillaryDatumDAO, NotFoundInDatastoreException}
-import org.slf4j.LoggerFactory
-
 import scala.concurrent.{ExecutionContext, Future}
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.repository.jpa.entity.CachedAncillaryDatumEntity
-import org.mbari.annosaurus.domain.CachedAncillaryDatum
-import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
-import org.mbari.annosaurus.etc.jdk.Logging.given
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumController.scala
@@ -81,7 +81,7 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
                             )
                         // TODO should this return the existing data?
                         None
-                    else {
+                    else
                         val cad = dao.newPersistentObject(
                             latitude,
                             longitude,
@@ -104,7 +104,6 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
 //                        println("---- " + cad)
                         imagedMoment.setAncillaryDatum(cad)
                         Some(cad)
-                    }
 
         for
             entity <- exec(fn)
@@ -126,11 +125,10 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
                         throw new RuntimeException(
                             s"ImagedMoment with UUID of $imagedMomentUuid already has ancillary data"
                         )
-                    else {
+                    else
                         val entity = datum.toEntity
                         imagedMoment.setAncillaryDatum(entity)
                         entity
-                    }
 
         for
             entity <- exec(fn)
@@ -289,10 +287,9 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
         if im.getAncillaryDatum != null then
             updateValues(im.getAncillaryDatum, d)
             im.getAncillaryDatum
-        else {
+        else
             im.setAncillaryDatum(d)
             im.getAncillaryDatum
-        }
 
     def merge(
         data: Iterable[CachedAncillaryDatum],
@@ -315,7 +312,7 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
                 cd.recordedTimestamp.map(_.toEpochMilli).getOrElse(-1L).toDouble
 
             if imagedMoments.isEmpty || usefulData.isEmpty then Seq.empty
-            else {
+            else
                 val mergedData = FastCollator(
                     imagedMoments,
                     imagedMomentToMillis,
@@ -330,7 +327,6 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
                 yield
                     val d = dao.newPersistentObject(cad.toEntity)
                     transform(createOrUpdate(d, im))
-            }
 
         exec(fn)
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumController.scala
@@ -31,14 +31,15 @@ import org.mbari.annosaurus.domain.CachedAncillaryDatum
 import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
 import org.mbari.annosaurus.etc.jdk.Logging.given
 
-/** @author
-  *   Brian Schlining
-  * @since 2017-05-01T10:53:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2017-05-01T10:53:00
+ */
 class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
     extends BaseController[CachedAncillaryDatumEntity, CachedAncillaryDatumDAO[
         CachedAncillaryDatumEntity
-    ], CachedAncillaryDatum] {
+    ], CachedAncillaryDatum]:
 
     protected type ADDAO = CachedAncillaryDatumDAO[CachedAncillaryDatumEntity]
     private val log = System.getLogger(getClass.getName)
@@ -68,23 +69,22 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
         phi: Option[Double] = None,
         theta: Option[Double] = None,
         psi: Option[Double] = None
-    )(implicit ec: ExecutionContext): Future[Option[CachedAncillaryDatum]] = {
+    )(implicit ec: ExecutionContext): Future[Option[CachedAncillaryDatum]] =
 
-        def fn(dao: ADDAO): Option[CachedAncillaryDatumEntity] = {
+        def fn(dao: ADDAO): Option[CachedAncillaryDatumEntity] =
             val imDao = daoFactory.newImagedMomentDAO(dao)
-            imDao.findByUUID(imagedMomentUuid) match {
+            imDao.findByUUID(imagedMomentUuid) match
                 case None               =>
                     log.atDebug.log(s"ImagedMoment with UUID of $imagedMomentUuid was no found")
                     None
                 case Some(imagedMoment) =>
-                    if (imagedMoment.getAncillaryDatum != null) {
+                    if imagedMoment.getAncillaryDatum != null then
                         log.atDebug
                             .log(
                                 s"ImagedMoment with UUID of $imagedMomentUuid already has ancillary data"
                             )
                         // TODO should this return the existing data?
                         None
-                    }
                     else {
                         val cad = dao.newPersistentObject(
                             latitude,
@@ -109,49 +109,42 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
                         imagedMoment.setAncillaryDatum(cad)
                         Some(cad)
                     }
-            }
-        }
 
         for
             entity <- exec(fn)
             dto    <- findByImagedMomentUUID(imagedMomentUuid) if entity.isDefined
         yield dto
-    }
 
     def create(imagedMomentUuid: UUID, datum: CachedAncillaryDatum)(implicit
         ec: ExecutionContext
-    ): Future[Option[CachedAncillaryDatum]] = {
-        def fn(dao: ADDAO): CachedAncillaryDatumEntity = {
+    ): Future[Option[CachedAncillaryDatum]] =
+        def fn(dao: ADDAO): CachedAncillaryDatumEntity =
             val imDao = daoFactory.newImagedMomentDAO(dao)
-            imDao.findByUUID(imagedMomentUuid) match {
+            imDao.findByUUID(imagedMomentUuid) match
                 case None               =>
                     throw new NotFoundInDatastoreException(
                         s"ImagedMoment with UUID of $imagedMomentUuid was no found"
                     )
                 case Some(imagedMoment) =>
-                    if (imagedMoment.getAncillaryDatum != null) {
+                    if imagedMoment.getAncillaryDatum != null then
                         throw new RuntimeException(
                             s"ImagedMoment with UUID of $imagedMomentUuid already has ancillary data"
                         )
-                    }
                     else {
                         val entity = datum.toEntity
                         imagedMoment.setAncillaryDatum(entity)
                         entity
                     }
-            }
-        }
 
         for
             entity <- exec(fn)
             dto    <- findByImagedMomentUUID(imagedMomentUuid)
         yield dto
-    }
 
     def create(
         datum: CachedAncillaryDatum
     )(implicit ec: ExecutionContext): Future[Option[CachedAncillaryDatum]] =
-        datum.imagedMomentUuid match {
+        datum.imagedMomentUuid match
             case None       =>
                 Future.failed(
                     new RuntimeException(
@@ -159,12 +152,11 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
                     )
                 )
             case Some(uuid) => create(uuid, datum)
-        }
 
     def update(
         datum: CachedAncillaryDatum
     )(implicit ec: ExecutionContext): Future[Option[CachedAncillaryDatum]] =
-        datum.uuid match {
+        datum.uuid match
             case None       =>
                 Future.failed(
                     new RuntimeException(
@@ -172,23 +164,20 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
                     )
                 )
             case Some(uuid) => update(uuid, datum)
-        }
 
     def update(uuid: UUID, datum: CachedAncillaryDatum)(implicit
         ec: ExecutionContext
-    ): Future[Option[CachedAncillaryDatum]] = {
-        def fn(dao: ADDAO): Option[CachedAncillaryDatum] = {
+    ): Future[Option[CachedAncillaryDatum]] =
+        def fn(dao: ADDAO): Option[CachedAncillaryDatum] =
             dao
                 .findByUUID(uuid)
-                .map(cad => {
+                .map(cad =>
                     updateValues(cad, datum.toEntity)
                     cad
-                })
+                )
                 .map(transform)
-        }
 
         exec(fn)
-    }
 
     def update(
         uuid: UUID,
@@ -209,12 +198,12 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
         phi: Option[Double] = None,
         theta: Option[Double] = None,
         psi: Option[Double] = None
-    )(implicit ec: ExecutionContext): Future[Option[CachedAncillaryDatum]] = {
+    )(implicit ec: ExecutionContext): Future[Option[CachedAncillaryDatum]] =
 
-        def fn(dao: ADDAO): Option[CachedAncillaryDatum] = {
+        def fn(dao: ADDAO): Option[CachedAncillaryDatum] =
             dao
                 .findByUUID(uuid)
-                .map(cad => {
+                .map(cad =>
                     latitude.foreach(cad.setLatitude(_))
                     longitude.foreach(cad.setLongitude(_))
                     depthMeters.foreach(cad.setDepthMeters(_))
@@ -233,74 +222,67 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
                     theta.foreach(cad.setTheta(_))
                     psi.foreach(cad.setPsi(_))
                     cad
-                })
+                )
                 .map(transform)
-        }
 
         exec(fn)
-    }
 
     def findByVideoReferenceUUID(
         uuid: UUID
-    )(implicit ec: ExecutionContext): Future[Seq[CachedAncillaryDatum]] = {
-        def fn(dao: ADDAO): Seq[CachedAncillaryDatum] = {
+    )(implicit ec: ExecutionContext): Future[Seq[CachedAncillaryDatum]] =
+        def fn(dao: ADDAO): Seq[CachedAncillaryDatum] =
             val imDao   = daoFactory.newImagedMomentDAO(dao)
             val moments = imDao.findByVideoReferenceUUID(uuid)
             moments
                 .filter(_.getAncillaryDatum != null)
                 .map(im => CachedAncillaryDatum.from(im.getAncillaryDatum, true))
                 .toSeq
-        }
 
         exec(fn)
-    }
 
     def findByObservationUUID(
         uuid: UUID
-    )(implicit ec: ExecutionContext): Future[Option[CachedAncillaryDatum]] = {
+    )(implicit ec: ExecutionContext): Future[Option[CachedAncillaryDatum]] =
         def fn(dao: ADDAO): Option[CachedAncillaryDatum] =
             dao.findDTOByObservationUuid(uuid)
                 .map(CachedAncillaryDatum.from)
 
         exec(fn)
-    }
 
     def findByImagedMomentUUID(
         uuid: UUID
-    )(implicit ec: ExecutionContext): Future[Option[CachedAncillaryDatum]] = {
+    )(implicit ec: ExecutionContext): Future[Option[CachedAncillaryDatum]] =
         def fn(dao: ADDAO): Option[CachedAncillaryDatum] =
             dao.findByImagedMomentUUID(uuid).map(transform)
 
         exec(fn)
-    }
 
     def bulkCreateOrUpdate(
         data: Seq[CachedAncillaryDatum]
-    )(implicit ec: ExecutionContext): Future[Seq[CachedAncillaryDatum]] = {
-        def fn(dao: ADDAO): Seq[CachedAncillaryDatum] = {
+    )(implicit ec: ExecutionContext): Future[Seq[CachedAncillaryDatum]] =
+        def fn(dao: ADDAO): Seq[CachedAncillaryDatum] =
             val fastDao = new FastAncillaryDataController(
                 dao.asInstanceOf[BaseDAO[?]].entityManager
             )
             fastDao.createOrUpdate(data)
             data
-        }
 
         exec(fn)
-    }
 
-    /** This method should be called within a transaction!
-      *
-      * @param d
-      *   This MUST be a persistable object! (Not a CahcedAncillaryDatumBean)
-      * @param im
-      *   The moment whose ancillary data is being updated
-      * @return
-      *   The CachedAncillaryDatum.
-      */
+    /**
+     * This method should be called within a transaction!
+     *
+     * @param d
+     *   This MUST be a persistable object! (Not a CahcedAncillaryDatumBean)
+     * @param im
+     *   The moment whose ancillary data is being updated
+     * @return
+     *   The CachedAncillaryDatum.
+     */
     private def createOrUpdate(
         d: CachedAncillaryDatumEntity,
         im: ImagedMomentEntity
-    ): CachedAncillaryDatumEntity = {
+    ): CachedAncillaryDatumEntity =
         require(d != null, "A null CachedAncillaryDatum argument is not allowed")
         require(im != null, "A null ImagedMoment argument is not allowed")
         require(
@@ -308,23 +290,21 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
             "The ImagedMoment should already be present in the database. (Null UUID was found"
         )
 
-        if (im.getAncillaryDatum != null) {
+        if im.getAncillaryDatum != null then
             updateValues(im.getAncillaryDatum, d)
             im.getAncillaryDatum
-        }
         else {
             im.setAncillaryDatum(d)
             im.getAncillaryDatum
         }
-    }
 
     def merge(
         data: Iterable[CachedAncillaryDatum],
         videoReferenceUuid: UUID,
         tolerance: Duration = Duration.ofMillis(7500)
-    )(implicit ec: ExecutionContext): Future[Seq[CachedAncillaryDatum]] = {
+    )(implicit ec: ExecutionContext): Future[Seq[CachedAncillaryDatum]] =
 
-        def fn(dao: ADDAO): Seq[CachedAncillaryDatum] = {
+        def fn(dao: ADDAO): Seq[CachedAncillaryDatum] =
             val imDao         = daoFactory.newImagedMomentDAO(dao)
             val imagedMoments = imDao
                 .findByVideoReferenceUUID(videoReferenceUuid)
@@ -338,9 +318,7 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
             def datumToMillis(cd: CachedAncillaryDatum) =
                 cd.recordedTimestamp.map(_.toEpochMilli).getOrElse(-1L).toDouble
 
-            if (imagedMoments.isEmpty || usefulData.isEmpty) {
-                Seq.empty
-            }
+            if imagedMoments.isEmpty || usefulData.isEmpty then Seq.empty
             else {
                 val mergedData = FastCollator(
                     imagedMoments,
@@ -350,31 +328,27 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
                     tolerance.toMillis.toDouble
                 )
 
-                for {
+                for
                     (im, opt) <- mergedData
                     cad       <- opt
-                } yield {
+                yield
                     val d = dao.newPersistentObject(cad.toEntity)
                     transform(createOrUpdate(d, im))
-                }
             }
-        }
 
         exec(fn)
-    }
 
     def deleteByVideoReferenceUuid(
         videoReferenceUuid: UUID
-    )(implicit ec: ExecutionContext): Future[Int] = {
+    )(implicit ec: ExecutionContext): Future[Int] =
         def fn(dao: ADDAO): Int = dao.deleteByVideoReferenceUuid(videoReferenceUuid)
 
         exec(fn)
-    }
 
     private def updateValues(
         a: CachedAncillaryDatumEntity,
         b: CachedAncillaryDatumEntity
-    ): Unit = {
+    ): Unit =
         require(a != null && b != null, "Null arguments are not allowed")
         a.setLatitude(b.getLatitude)
         a.setLongitude(b.getLongitude)
@@ -393,5 +367,3 @@ class CachedAncillaryDatumController(val daoFactory: JPADAOFactory)
         a.setPhi(b.getPhi)
         a.setTheta(b.getTheta)
         a.setPsi(b.getPsi)
-    }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedVideoReferenceInfoController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedVideoReferenceInfoController.scala
@@ -25,14 +25,15 @@ import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.domain.CachedVideoReferenceInfo
 import org.checkerframework.checker.units.qual.C
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-09-14T10:50:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-09-14T10:50:00
+ */
 class CachedVideoReferenceInfoController(val daoFactory: JPADAOFactory)
     extends BaseController[CachedVideoReferenceInfoEntity, CachedVideoReferenceInfoDAO[
         CachedVideoReferenceInfoEntity
-    ], CachedVideoReferenceInfo] {
+    ], CachedVideoReferenceInfo]:
 
     protected type VRDAO = CachedVideoReferenceInfoDAO[CachedVideoReferenceInfoEntity]
 
@@ -47,64 +48,56 @@ class CachedVideoReferenceInfoController(val daoFactory: JPADAOFactory)
 
     def findByVideoReferenceUUID(
         uuid: UUID
-    )(implicit ec: ExecutionContext): Future[Option[CachedVideoReferenceInfo]] = {
+    )(implicit ec: ExecutionContext): Future[Option[CachedVideoReferenceInfo]] =
         def fn(dao: VRDAO): Option[CachedVideoReferenceInfo] =
             dao.findByVideoReferenceUUID(uuid).map(transform)
         exec(fn)
-    }
 
     def findByPlatformName(
         name: String
-    )(implicit ec: ExecutionContext): Future[Iterable[CachedVideoReferenceInfo]] = {
+    )(implicit ec: ExecutionContext): Future[Iterable[CachedVideoReferenceInfo]] =
         def fn(dao: VRDAO): Iterable[CachedVideoReferenceInfo] =
             dao.findByPlatformName(name).map(transform)
         exec(fn)
-    }
 
     def findByMissionId(
         id: String
-    )(implicit ec: ExecutionContext): Future[Iterable[CachedVideoReferenceInfo]] = {
+    )(implicit ec: ExecutionContext): Future[Iterable[CachedVideoReferenceInfo]] =
         def fn(dao: VRDAO): Iterable[CachedVideoReferenceInfo] =
             dao.findByMissionID(id).map(transform)
         exec(fn)
-    }
 
     def findByMissionContact(
         contact: String
-    )(implicit ec: ExecutionContext): Future[Iterable[CachedVideoReferenceInfo]] = {
+    )(implicit ec: ExecutionContext): Future[Iterable[CachedVideoReferenceInfo]] =
         def fn(dao: VRDAO): Iterable[CachedVideoReferenceInfo] =
             dao.findByMissionContact(contact).map(transform)
         exec(fn)
-    }
 
-    def findAllMissionContacts()(implicit ec: ExecutionContext): Future[Iterable[String]] = {
+    def findAllMissionContacts()(implicit ec: ExecutionContext): Future[Iterable[String]] =
         def fn(dao: VRDAO): Iterable[String] = dao.findAllMissionContacts()
         exec(fn)
-    }
 
-    def findAllPlatformNames()(implicit ec: ExecutionContext): Future[Iterable[String]] = {
+    def findAllPlatformNames()(implicit ec: ExecutionContext): Future[Iterable[String]] =
         def fn(dao: VRDAO): Iterable[String] = dao.findAllPlatformNames()
         exec(fn)
-    }
 
-    def findAllMissionIds()(implicit ec: ExecutionContext): Future[Iterable[String]] = {
+    def findAllMissionIds()(implicit ec: ExecutionContext): Future[Iterable[String]] =
         def fn(dao: VRDAO): Iterable[String] = dao.findAllMissionIDs()
         exec(fn)
-    }
 
-    def findAllVideoReferenceUUIDs()(implicit ec: ExecutionContext): Future[Iterable[UUID]] = {
+    def findAllVideoReferenceUUIDs()(implicit ec: ExecutionContext): Future[Iterable[UUID]] =
         def fn(dao: VRDAO): Iterable[UUID] = dao.findAllVideoReferenceUUIDs()
         exec(fn)
-    }
 
     def create(
         videoReferenceUUID: UUID,
         platformName: String,
         missionID: String,
         missionContact: Option[String] = None
-    )(implicit ec: ExecutionContext): Future[CachedVideoReferenceInfo] = {
+    )(implicit ec: ExecutionContext): Future[CachedVideoReferenceInfo] =
 
-        def fn(dao: VRDAO): CachedVideoReferenceInfo = {
+        def fn(dao: VRDAO): CachedVideoReferenceInfo =
             val v = new CachedVideoReferenceInfoEntity
             v.setVideoReferenceUuid(videoReferenceUUID)
             v.setPlatformName(platformName)
@@ -112,13 +105,11 @@ class CachedVideoReferenceInfoController(val daoFactory: JPADAOFactory)
             missionContact.foreach(v.setMissionContact)
             dao.create(v)
             transform(v)
-        }
         exec(fn)
-    }
 
     def update(
         info: CachedVideoReferenceInfo
-    )(using ec: ExecutionContext): Future[Option[CachedVideoReferenceInfo]] = {
+    )(using ec: ExecutionContext): Future[Option[CachedVideoReferenceInfo]] =
         update(
             info.uuid,
             Option(info.videoReferenceUuid),
@@ -126,7 +117,6 @@ class CachedVideoReferenceInfoController(val daoFactory: JPADAOFactory)
             info.missionId,
             info.missionContact
         )
-    }
 
     def update(
         uuid: UUID,
@@ -134,9 +124,9 @@ class CachedVideoReferenceInfoController(val daoFactory: JPADAOFactory)
         platformName: Option[String] = None,
         missionID: Option[String] = None,
         missionContact: Option[String] = None
-    )(implicit ec: ExecutionContext): Future[Option[CachedVideoReferenceInfo]] = {
+    )(implicit ec: ExecutionContext): Future[Option[CachedVideoReferenceInfo]] =
 
-        def fn(dao: VRDAO): Option[CachedVideoReferenceInfo] = dao.findByUUID(uuid) match {
+        def fn(dao: VRDAO): Option[CachedVideoReferenceInfo] = dao.findByUUID(uuid) match
             case None    => None
             case Some(v) =>
                 videoReferenceUUID.foreach(v.setVideoReferenceUuid)
@@ -144,8 +134,4 @@ class CachedVideoReferenceInfoController(val daoFactory: JPADAOFactory)
                 missionID.foreach(v.setMissionId)
                 missionContact.foreach(v.setMissionContact)
                 Some(transform(v))
-        }
         exec(fn)
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedVideoReferenceInfoController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/CachedVideoReferenceInfoController.scala
@@ -16,14 +16,13 @@
 
 package org.mbari.annosaurus.controllers
 
-import org.mbari.annosaurus.repository.CachedVideoReferenceInfoDAO
-import java.util.UUID
-
-import scala.concurrent.{ExecutionContext, Future}
-import org.mbari.annosaurus.repository.jpa.entity.CachedVideoReferenceInfoEntity
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.domain.CachedVideoReferenceInfo
-import org.checkerframework.checker.units.qual.C
+import org.mbari.annosaurus.repository.CachedVideoReferenceInfoDAO
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import org.mbari.annosaurus.repository.jpa.entity.CachedVideoReferenceInfoEntity
+
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataController.scala
@@ -18,7 +18,7 @@ package org.mbari.annosaurus.controllers
 
 import jakarta.persistence.EntityManager
 import org.mbari.annosaurus.domain.CachedAncillaryDatum
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+import org.mbari.annosaurus.etc.jdk.Loggers.{*, given}
 
 import java.sql.Timestamp
 import java.time.Instant

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataController.scala
@@ -16,17 +16,15 @@
 
 package org.mbari.annosaurus.controllers
 
+import jakarta.persistence.EntityManager
+import org.mbari.annosaurus.domain.CachedAncillaryDatum
+import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+
 import java.sql.Timestamp
 import java.time.Instant
 import java.util.UUID
-
-import jakarta.persistence.EntityManager
-
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.domain.CachedAncillaryDatum
-import org.mbari.annosaurus.repository.jpa.extensions.*
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataController.scala
@@ -23,16 +23,17 @@ import java.util.UUID
 import jakarta.persistence.EntityManager
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import org.mbari.annosaurus.domain.CachedAncillaryDatum
 import org.mbari.annosaurus.repository.jpa.extensions.*
 import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
 
-/** @author
-  *   Brian Schlining
-  * @since 2019-02-13T14:35:00
-  */
-class FastAncillaryDataController(val entityManager: EntityManager) {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2019-02-13T14:35:00
+ */
+class FastAncillaryDataController(val entityManager: EntityManager):
 
     private val tableName = "ancillary_data"
 
@@ -40,20 +41,18 @@ class FastAncillaryDataController(val entityManager: EntityManager) {
 
     // Needs to be called in a transaction
     def createOrUpdate(data: Seq[CachedAncillaryDatum])(using ec: ExecutionContext): Unit =
-        for (d <- data) {
+        for d <- data do
             val ok = createOrUpdate(d)
-            if (!ok) {
+            if !ok then
                 val msg =
                     "Failed to create or update ancillary data with imagedMomentUuid = " + d.imagedMomentUuid
                 log.atError.log(msg)
                 throw new RuntimeException(msg)
-            }
-        }
 
     protected def createOrUpdate(data: CachedAncillaryDatum): Boolean =
-        if (exists(data)) update(data) else create(data)
+        if exists(data) then update(data) else create(data)
 
-    def exists(data: CachedAncillaryDatum): Boolean = {
+    def exists(data: CachedAncillaryDatum): Boolean =
         data.imagedMomentUuid match
             case None                   => false
             case Some(imagedMomentUuid) =>
@@ -67,15 +66,15 @@ class FastAncillaryDataController(val entityManager: EntityManager) {
                     .asScala
                     .size
                 n > 0
-    }
 
-    /** Creates a new AncillaryData record. Must be called in a transaction!! In general you should
-      * use createOrUpdate instead.
-      * @param data
-      * @return
-      */
-    def create(data: CachedAncillaryDatum): Boolean = {
-        if (data.imagedMomentUuid.isEmpty) false
+    /**
+     * Creates a new AncillaryData record. Must be called in a transaction!! In general you should use createOrUpdate
+     * instead.
+     * @param data
+     * @return
+     */
+    def create(data: CachedAncillaryDatum): Boolean =
+        if data.imagedMomentUuid.isEmpty then false
         else
             val uuid    = data.uuid.getOrElse(UUID.randomUUID())
             val sqlData = dataAsSql(data) +
@@ -90,9 +89,8 @@ class FastAncillaryDataController(val entityManager: EntityManager) {
                 .createNativeQuery(sql)
                 .executeUpdate()
             n == 1
-    }
 
-    def update(data: CachedAncillaryDatum): Boolean = {
+    def update(data: CachedAncillaryDatum): Boolean =
         val values = dataAsSql(data)
             .map { case (a, b) => s"$a = $b" }
             .mkString(", ")
@@ -102,9 +100,8 @@ class FastAncillaryDataController(val entityManager: EntityManager) {
             .createNativeQuery(sql)
             .executeUpdate()
         n == 1
-    }
 
-    private def dataAsSql(datum: CachedAncillaryDatum): Map[String, String] = {
+    private def dataAsSql(datum: CachedAncillaryDatum): Map[String, String] =
         require(datum.imagedMomentUuid != null)
         val lastUpdated = Timestamp.from(Instant.now())
 
@@ -127,6 +124,3 @@ class FastAncillaryDataController(val entityManager: EntityManager) {
             datum.pressureDbar.map(v => "pressure_dbar" -> s"$v") ::
             Some("last_updated_timestamp" -> s"'$lastUpdated'") ::
             Nil).flatten.toMap
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataController.scala
@@ -18,7 +18,7 @@ package org.mbari.annosaurus.controllers
 
 import jakarta.persistence.EntityManager
 import org.mbari.annosaurus.domain.CachedAncillaryDatum
-import org.mbari.annosaurus.etc.jdk.Loggers.{*, given}
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 
 import java.sql.Timestamp
 import java.time.Instant

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageController.scala
@@ -16,19 +16,16 @@
 
 package org.mbari.annosaurus.controllers
 
+import org.mbari.annosaurus.domain.{Image, ImageCreateSC}
+import org.mbari.annosaurus.repository.ImagedMomentDAO
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import org.mbari.annosaurus.repository.jpa.entity.{ImageReferenceEntity, ImagedMomentEntity}
+import org.mbari.vcr4j.time.Timecode
+
 import java.net.URL
 import java.time.{Duration, Instant}
 import java.util.UUID
-import org.mbari.annosaurus.repository.ImagedMomentDAO
-import org.mbari.annosaurus.domain.{Image, ImageCreateSC}
-import org.mbari.vcr4j.time.Timecode
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
-
 import scala.concurrent.{ExecutionContext, Future}
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
-import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
-
 import scala.jdk.CollectionConverters.*
 
 /**

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageController.scala
@@ -243,8 +243,7 @@ class ImageController(daoFactory: JPADAOFactory):
                     then
                         val imDao = daoFactory.newImagedMomentDAO(d)
                         imDao.delete(imagedMoment)
-                    else
-                        imagedMoment.removeImageReference(imageReference)
+                    else imagedMoment.removeImageReference(imageReference)
 //                        d.delete(imageReference)
                     true
         )

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageController.scala
@@ -31,24 +31,24 @@ import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
 
 import scala.jdk.CollectionConverters.*
 
-/** Created by brian on 7/14/16.
-  */
-class ImageController(daoFactory: JPADAOFactory) {
+/**
+ * Created by brian on 7/14/16.
+ */
+class ImageController(daoFactory: JPADAOFactory):
 
     private val log = System.getLogger(getClass.getName)
 
-    def findByUUID(uuid: UUID)(implicit ec: ExecutionContext): Future[Option[Image]] = {
+    def findByUUID(uuid: UUID)(implicit ec: ExecutionContext): Future[Option[Image]] =
         val irDao = daoFactory.newImageReferenceDAO()
         val f     = irDao.runTransaction(d => irDao.findByUUID(uuid))
         f.onComplete(t => irDao.close())
         f.map(_.map(Image.from(_, true)))
-    }
 
     def findByVideoReferenceUUID(
         videoReferenceUUID: UUID,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    )(implicit ec: ExecutionContext): Future[Seq[Image]] = {
+    )(implicit ec: ExecutionContext): Future[Seq[Image]] =
         val dao = daoFactory.newImagedMomentDAO()
         val f   =
             dao.runTransaction(d =>
@@ -58,9 +58,8 @@ class ImageController(daoFactory: JPADAOFactory) {
             ).map(_.toSeq)
         f.onComplete(t => dao.close())
         f
-    }
 
-    def findByURL(url: URL)(implicit ec: ExecutionContext): Future[Option[Image]] = {
+    def findByURL(url: URL)(implicit ec: ExecutionContext): Future[Option[Image]] =
         val dao = daoFactory.newImageReferenceDAO()
         val f   = dao.runTransaction(d =>
             d.findByURL(url)
@@ -68,9 +67,8 @@ class ImageController(daoFactory: JPADAOFactory) {
         )
         f.onComplete(_ => dao.close())
         f
-    }
 
-    def findByImageName(name: String)(implicit ec: ExecutionContext): Future[Seq[Image]] = {
+    def findByImageName(name: String)(implicit ec: ExecutionContext): Future[Seq[Image]] =
         val dao = daoFactory.newImageReferenceDAO()
         val f   = dao.runTransaction(d =>
             d.findByImageName(name)
@@ -78,14 +76,14 @@ class ImageController(daoFactory: JPADAOFactory) {
         )
         f.onComplete(t => dao.close())
         f
-    }
 
-    /** @param imageCreates
-      *   The image data to create
-      * @param ec
-      * @return
-      *   Only the newly created images. If an image already exists, it is not returned.
-      */
+    /**
+     * @param imageCreates
+     *   The image data to create
+     * @param ec
+     * @return
+     *   Only the newly created images. If an image already exists, it is not returned.
+     */
     def bulkCreate(imageCreates: Seq[ImageCreateSC])(using
         ec: ExecutionContext
     ): Future[Seq[Image]] =
@@ -93,12 +91,10 @@ class ImageController(daoFactory: JPADAOFactory) {
         val irDao      = daoFactory.newImageReferenceDAO(imDao)
         val candidates = imageCreates.distinctBy(_.url)
         // prefilter
-        if (candidates.isEmpty) {
-            return Future.successful(Seq.empty)
-        }
+        if candidates.isEmpty then return Future.successful(Seq.empty)
         val f          = for
             newOnes      <- irDao.runTransaction(d => candidates.filter(c => d.findByURL(c.url).isEmpty))
-            newlyCreated <- irDao.runTransaction(d => {
+            newlyCreated <- irDao.runTransaction(d =>
                                 for ic <- newOnes
                                 yield
                                     val imagedMoment   = ImagedMomentController
@@ -119,11 +115,9 @@ class ImageController(daoFactory: JPADAOFactory) {
                                     imagedMoment.addImageReference(imageReference)
                                     irDao.flush()
                                     imageReference
-                            })
+                            )
             persisted    <-
-                irDao.runTransaction(d =>
-                    newlyCreated.flatMap(i => d.findByUUID(i.getUuid).map(Image.from(_, true)))
-                )
+                irDao.runTransaction(d => newlyCreated.flatMap(i => d.findByUUID(i.getUuid).map(Image.from(_, true))))
         yield persisted
 
         f.onComplete(t => irDao.close())
@@ -139,11 +133,11 @@ class ImageController(daoFactory: JPADAOFactory) {
         width: Option[Int] = None,
         height: Option[Int] = None,
         description: Option[String] = None
-    )(implicit ec: ExecutionContext): Future[Image] = {
+    )(implicit ec: ExecutionContext): Future[Image] =
 
         val imDao = daoFactory.newImagedMomentDAO()
         val irDao = daoFactory.newImageReferenceDAO(imDao)
-        val f     = irDao.runTransaction(d => {
+        val f     = irDao.runTransaction(d =>
             val imagedMoment   = ImagedMomentController
                 .findOrCreateImagedMoment(
                     imDao,
@@ -158,27 +152,26 @@ class ImageController(daoFactory: JPADAOFactory) {
             imagedMoment.addImageReference(imageReference)
             d.flush()
             Image.from(imageReference, true)
-        })
+        )
         f.onComplete(t => irDao.close())
         f
-    }
 
-    /** Update params. Note that if you provide video indices then the image is moved, the indices
-      * are not updated in place as this would effect any observations or images associated with the
-      * same image moment. If you want to change the indices in place, use the the
-      * ImageMomentController instead.
-      * @param imageReferenceUuid
-      * @param videoReferenceUUID
-      * @param timecode
-      * @param elapsedTime
-      * @param recordedDate
-      * @param format
-      * @param width
-      * @param height
-      * @param description
-      * @param ec
-      * @return
-      */
+    /**
+     * Update params. Note that if you provide video indices then the image is moved, the indices are not updated in
+     * place as this would effect any observations or images associated with the same image moment. If you want to
+     * change the indices in place, use the the ImageMomentController instead.
+     * @param imageReferenceUuid
+     * @param videoReferenceUUID
+     * @param timecode
+     * @param elapsedTime
+     * @param recordedDate
+     * @param format
+     * @param width
+     * @param height
+     * @param description
+     * @param ec
+     * @return
+     */
     def update(
         imageReferenceUuid: UUID,
         videoReferenceUUID: Option[UUID] = None,
@@ -190,15 +183,15 @@ class ImageController(daoFactory: JPADAOFactory) {
         width: Option[Int] = None,
         height: Option[Int] = None,
         description: Option[String] = None
-    )(implicit ec: ExecutionContext): Future[Option[Image]] = {
+    )(implicit ec: ExecutionContext): Future[Option[Image]] =
 
         val imDao = daoFactory.newImagedMomentDAO()
         val irDao = daoFactory.newImageReferenceDAO(imDao)
 
-        val f = irDao.runTransaction(d => {
+        val f = irDao.runTransaction(d =>
             val opt = d.findByUUID(imageReferenceUuid)
 
-            opt.map(ir => {
+            opt.map(ir =>
 
                 url.foreach(ir.setUrl)
                 format.foreach(ir.setFormat)
@@ -208,7 +201,7 @@ class ImageController(daoFactory: JPADAOFactory) {
                 d.flush()
 
                 val vrUUID = videoReferenceUUID.getOrElse(ir.getImagedMoment.getVideoReferenceUuid)
-                if (timecode.isDefined || elapsedTime.isDefined || recordedDate.isDefined) {
+                if timecode.isDefined || elapsedTime.isDefined || recordedDate.isDefined then
                     // change indices
                     val newIm = ImagedMomentController
                         .findOrCreateImagedMoment(
@@ -219,8 +212,7 @@ class ImageController(daoFactory: JPADAOFactory) {
                             elapsedTime
                         )
                     move(imDao, newIm, ir)
-                }
-                else if (videoReferenceUUID.isDefined) {
+                else if videoReferenceUUID.isDefined then
                     val imagedMoment = ir.getImagedMoment
                     // move to new video-reference/imaged-moment using the existing images
                     val tc           = Option(imagedMoment.getTimecode)
@@ -229,62 +221,47 @@ class ImageController(daoFactory: JPADAOFactory) {
                     val newIm        =
                         ImagedMomentController.findOrCreateImagedMoment(imDao, vrUUID, tc, rd, et)
                     move(imDao, newIm, ir)
-                }
-
-            })
-        })
+            )
+        )
 
         val g = f.flatMap(opt =>
-            opt.map(i =>
-                irDao.runTransaction(d => d.findByUUID(imageReferenceUuid).map(Image.from(_, true)))
-            ).getOrElse(Future(None))
+            opt.map(i => irDao.runTransaction(d => d.findByUUID(imageReferenceUuid).map(Image.from(_, true))))
+                .getOrElse(Future(None))
         )
 
         g.onComplete(_ => irDao.close())
         g
-    }
 
-    def delete(uuid: UUID)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def delete(uuid: UUID)(implicit ec: ExecutionContext): Future[Boolean] =
         val imDao = daoFactory.newImagedMomentDAO()
         val irDao = daoFactory.newImageReferenceDAO(imDao)
-        val f     = irDao.runTransaction(d => {
-            d.findByUUID(uuid) match {
+        val f     = irDao.runTransaction(d =>
+            d.findByUUID(uuid) match
                 case None                 => false
                 case Some(imageReference) =>
                     val imagedMoment = imageReference.getImagedMoment
-                    if (
-                        imagedMoment.getImageReferences.size == 1 && imagedMoment
+                    if imagedMoment.getImageReferences.size == 1 && imagedMoment
                             .getObservations
                             .isEmpty
-                    ) {
+                    then
                         val imDao = daoFactory.newImagedMomentDAO(d)
                         imDao.delete(imagedMoment)
-                    }
-                    else {
+                    else
                         imagedMoment.removeImageReference(imageReference)
 //                        d.delete(imageReference)
-                    }
                     true
-            }
-        })
+        )
         f.onComplete(t => irDao.close())
         f
-    }
 
     private def move(
         dao: ImagedMomentDAO[ImagedMomentEntity],
         newIm: ImagedMomentEntity,
         imageReference: ImageReferenceEntity
-    ): Unit = {
+    ): Unit =
         val oldIm = imageReference.getImagedMoment
-        if (!oldIm.getUuid.equals(newIm.getUuid)) {
+        if !oldIm.getUuid.equals(newIm.getUuid) then
             val shouldDelete = oldIm.getImageReferences.size == 1 && oldIm.getObservations.isEmpty
             oldIm.removeImageReference(imageReference)
             newIm.addImageReference(imageReference)
-            if (shouldDelete) {
-                dao.delete(oldIm)
-            }
-        }
-    }
-
-}
+            if shouldDelete then dao.delete(oldIm)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageReferenceController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageReferenceController.scala
@@ -123,8 +123,7 @@ class ImageReferenceController(val daoFactory: JPADAOFactory)
                     then
                         val imDao = daoFactory.newImagedMomentDAO(dao)
                         imDao.delete(imagedMoment)
-                    else
-                        imagedMoment.removeImageReference(imageReference)
+                    else imagedMoment.removeImageReference(imageReference)
 //                        dao.delete(imageReference)
                     true
         exec(fn)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageReferenceController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageReferenceController.scala
@@ -16,15 +16,14 @@
 
 package org.mbari.annosaurus.controllers
 
+import org.mbari.annosaurus.domain.ImageReference
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
 import org.mbari.annosaurus.repository.{ImageReferenceDAO, NotFoundInDatastoreException}
 
 import java.net.URL
 import java.util.UUID
-
 import scala.concurrent.{ExecutionContext, Future}
-import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.domain.ImageReference
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageReferenceController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImageReferenceController.scala
@@ -26,14 +26,15 @@ import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.domain.ImageReference
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-07-04T22:15:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-07-04T22:15:00
+ */
 class ImageReferenceController(val daoFactory: JPADAOFactory)
     extends BaseController[ImageReferenceEntity, ImageReferenceDAO[
         ImageReferenceEntity
-    ], ImageReference] {
+    ], ImageReference]:
 
     type IRDAO = ImageReferenceDAO[ImageReferenceEntity]
 
@@ -48,11 +49,11 @@ class ImageReferenceController(val daoFactory: JPADAOFactory)
         heightPixels: Option[Int] = None,
         widthPixels: Option[Int] = None,
         format: Option[String] = None
-    )(implicit ec: ExecutionContext): Future[ImageReference] = {
+    )(implicit ec: ExecutionContext): Future[ImageReference] =
 
-        def fn(dao: IRDAO): ImageReference = {
+        def fn(dao: IRDAO): ImageReference =
             val imDao = daoFactory.newImagedMomentDAO()
-            imDao.findByUUID(imagedMomentUUID) match {
+            imDao.findByUUID(imagedMomentUUID) match
                 case None               =>
                     throw new NotFoundInDatastoreException(
                         s"No ImagedMoment with UUID of $imagedMomentUUID was found"
@@ -62,11 +63,8 @@ class ImageReferenceController(val daoFactory: JPADAOFactory)
                         dao.newPersistentObject(url, description, heightPixels, widthPixels, format)
                     imagedMoment.addImageReference(imageReference)
                     transform(imageReference)
-            }
-        }
 
         exec(fn)
-    }
 
     def update(
         uuid: UUID,
@@ -76,21 +74,21 @@ class ImageReferenceController(val daoFactory: JPADAOFactory)
         widthPixels: Option[Int] = None,
         format: Option[String] = None,
         imagedMomentUUID: Option[UUID] = None
-    )(implicit ec: ExecutionContext): Future[Option[ImageReference]] = {
+    )(implicit ec: ExecutionContext): Future[Option[ImageReference]] =
 
-        def fn(dao: IRDAO): Option[ImageReference] = {
+        def fn(dao: IRDAO): Option[ImageReference] =
             dao
                 .findByUUID(uuid)
-                .map(imageReference => {
+                .map(imageReference =>
                     url.foreach(imageReference.setUrl)
                     description.foreach(imageReference.setDescription)
                     heightPixels.foreach(imageReference.setHeight(_))
                     widthPixels.foreach(imageReference.setWidth(_))
                     format.foreach(imageReference.setFormat)
-                    imagedMomentUUID.foreach(imUUID => {
+                    imagedMomentUUID.foreach(imUUID =>
                         val imDao = daoFactory.newImagedMomentDAO(dao)
                         val newIm = imDao.findByUUID(imUUID)
-                        newIm match {
+                        newIm match
                             case None               =>
                                 throw new NotFoundInDatastoreException(
                                     s"ImagedMoment with UUID of $imUUID no found"
@@ -98,46 +96,36 @@ class ImageReferenceController(val daoFactory: JPADAOFactory)
                             case Some(imagedMoment) =>
                                 imageReference.getImagedMoment.removeImageReference(imageReference)
                                 imagedMoment.addImageReference(imageReference)
-                        }
-                    })
+                    )
                     dao.flush()
                     transform(imageReference)
-                })
-        }
+                )
 
         exec(fn)
-    }
 
-    /** This controller will also delete the [[MutableImagedMoment]] if it is empty (i.e. no
-      * observations or other imageReferences)
-      *
-      * @param uuid
-      * @param ec
-      * @return
-      */
-    override def delete(uuid: UUID)(implicit ec: ExecutionContext): Future[Boolean] = {
-        def fn(dao: IRDAO): Boolean = {
-            dao.findByUUID(uuid) match {
+    /**
+     * This controller will also delete the [[MutableImagedMoment]] if it is empty (i.e. no observations or other
+     * imageReferences)
+     *
+     * @param uuid
+     * @param ec
+     * @return
+     */
+    override def delete(uuid: UUID)(implicit ec: ExecutionContext): Future[Boolean] =
+        def fn(dao: IRDAO): Boolean =
+            dao.findByUUID(uuid) match
                 case None                 => false
                 case Some(imageReference) =>
                     val imagedMoment = imageReference.getImagedMoment
                     // If this is the only imageref and there are no observations, delete the imagemoment
-                    if (
-                        imagedMoment.getImageReferences.size == 1 && imagedMoment
+                    if imagedMoment.getImageReferences.size == 1 && imagedMoment
                             .getObservations
                             .isEmpty
-                    ) {
+                    then
                         val imDao = daoFactory.newImagedMomentDAO(dao)
                         imDao.delete(imagedMoment)
-                    }
-                    else {
+                    else
                         imagedMoment.removeImageReference(imageReference)
 //                        dao.delete(imageReference)
-                    }
                     true
-            }
-        }
         exec(fn)
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentController.scala
@@ -17,7 +17,7 @@
 package org.mbari.annosaurus.controllers
 
 import org.mbari.annosaurus.domain.{ImagedMoment, WindowRequest}
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.repository.jpa.entity.{AssociationEntity, ImagedMomentEntity}
 import org.mbari.annosaurus.repository.{DAO, ImagedMomentDAO, NotFoundInDatastoreException}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentController.scala
@@ -16,22 +16,19 @@
 
 package org.mbari.annosaurus.controllers
 
-import java.io.Closeable
-import java.time.{Duration, Instant}
-import java.util.UUID
-import org.mbari.annosaurus.domain.{Annotation, ImageCreateSC, ImagedMoment, WindowRequest}
-import org.mbari.annosaurus.repository.{DAO, ImagedMomentDAO, NotFoundInDatastoreException}
-import org.mbari.vcr4j.time.Timecode
-import org.slf4j.LoggerFactory
-
-import scala.concurrent.{ExecutionContext, Future}
+import org.mbari.annosaurus.domain.{ImagedMoment, WindowRequest}
+import org.mbari.annosaurus.etc.jdk.Logging.given
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.repository.jpa.entity.{AssociationEntity, ImagedMomentEntity}
+import org.mbari.annosaurus.repository.{DAO, ImagedMomentDAO, NotFoundInDatastoreException}
+import org.mbari.vcr4j.time.Timecode
 
-import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.etc.jdk.Logging.given
-
+import java.io.Closeable
+import java.time.{Duration, Instant}
 import java.util
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters.*
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentController.scala
@@ -33,12 +33,13 @@ import org.mbari.annosaurus.etc.jdk.Logging.given
 
 import java.util
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T16:06:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T16:06:00
+ */
 class ImagedMomentController(val daoFactory: JPADAOFactory)
-    extends BaseController[ImagedMomentEntity, ImagedMomentDAO[ImagedMomentEntity], ImagedMoment] {
+    extends BaseController[ImagedMomentEntity, ImagedMomentDAO[ImagedMomentEntity], ImagedMoment]:
 
     protected type IMDAO = ImagedMomentDAO[ImagedMomentEntity]
 
@@ -73,8 +74,8 @@ class ImagedMomentController(val daoFactory: JPADAOFactory)
     ): Future[Int] =
         exec(d => d.countWithImages())
 
-    def findByLinkName(linkName: String, limit: Option[Int] = None, offset: Option[Int] = None)(
-        implicit ec: ExecutionContext
+    def findByLinkName(linkName: String, limit: Option[Int] = None, offset: Option[Int] = None)(implicit
+        ec: ExecutionContext
     ): Future[Iterable[ImagedMoment]] =
         exec(d => d.findByLinkName(linkName, limit, offset).map(transform))
 
@@ -88,46 +89,41 @@ class ImagedMomentController(val daoFactory: JPADAOFactory)
     ): Future[Iterable[UUID]] =
         exec(d => d.findAllVideoReferenceUUIDs(limit, offset))
 
-    def findByVideoReferenceUUID(uuid: UUID, limit: Option[Int] = None, offset: Option[Int] = None)(
-        implicit ec: ExecutionContext
+    def findByVideoReferenceUUID(uuid: UUID, limit: Option[Int] = None, offset: Option[Int] = None)(implicit
+        ec: ExecutionContext
     ): Future[Iterable[ImagedMoment]] =
         exec(d => d.findByVideoReferenceUUID(uuid, limit, offset).map(transform))
 
-    /** @param uuid
-      * @param limit
-      * @param offset
-      * @return
-      *   A butple of a closeable, and a stream. When the stream is done being processed invoke the
-      *   closeable
-      */
+    /**
+     * @param uuid
+     * @param limit
+     * @param offset
+     * @return
+     *   A butple of a closeable, and a stream. When the stream is done being processed invoke the closeable
+     */
     def streamByVideoReferenceUUID(
         uuid: UUID,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    ): (Closeable, java.util.stream.Stream[ImagedMomentEntity]) = {
+    ): (Closeable, java.util.stream.Stream[ImagedMomentEntity]) =
         val dao = daoFactory.newImagedMomentDAO()
         (() => dao.close(), dao.streamByVideoReferenceUUID(uuid, limit, offset))
-    }
 
     def findByImageReferenceUUID(
         uuid: UUID
-    )(implicit ec: ExecutionContext): Future[Option[ImagedMoment]] = {
-        def fn(dao: IMDAO): Option[ImagedMoment] = {
+    )(implicit ec: ExecutionContext): Future[Option[ImagedMoment]] =
+        def fn(dao: IMDAO): Option[ImagedMoment] =
             val irDao = daoFactory.newImageReferenceDAO(dao)
             irDao.findByUUID(uuid).map(_.getImagedMoment).map(transform)
-        }
         exec(fn)
-    }
 
     def findByObservationUUID(
         uuid: UUID
-    )(implicit ec: ExecutionContext): Future[Option[ImagedMoment]] = {
-        def fn(dao: IMDAO): Option[ImagedMoment] = {
+    )(implicit ec: ExecutionContext): Future[Option[ImagedMoment]] =
+        def fn(dao: IMDAO): Option[ImagedMoment] =
             val obsDao = daoFactory.newObservationDAO(dao)
             obsDao.findByUUID(uuid).map(_.getImagedMoment).map(transform)
-        }
         exec(fn)
-    }
 
     def findWithImageReferences(
         videoReferenceUUID: UUID
@@ -139,46 +135,40 @@ class ImagedMomentController(val daoFactory: JPADAOFactory)
         end: Instant,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    )(implicit ec: ExecutionContext): Future[Seq[ImagedMoment]] = {
+    )(implicit ec: ExecutionContext): Future[Seq[ImagedMoment]] =
         val imDao = daoFactory.newImagedMomentDAO()
-        val f     = imDao.runTransaction(d =>
-            d.findBetweenUpdatedDates(start, end, limit, offset).map(transform)
-        )
+        val f     = imDao.runTransaction(d => d.findBetweenUpdatedDates(start, end, limit, offset).map(transform))
         f.onComplete(_ => imDao.close())
         f.map(_.toSeq)
-    }
 
     def streamBetweenUpdatedDates(
         start: Instant,
         end: Instant,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    ): (Closeable, java.util.stream.Stream[ImagedMomentEntity]) = {
+    ): (Closeable, java.util.stream.Stream[ImagedMomentEntity]) =
         val dao = daoFactory.newImagedMomentDAO()
         (() => dao.close(), dao.streamBetweenUpdatedDates(start, end, limit, offset))
-    }
 
     def streamVideoReferenceUuidsBetweenUpdatedDates(
         start: Instant,
         end: Instant,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    ): (Closeable, java.util.stream.Stream[UUID]) = {
+    ): (Closeable, java.util.stream.Stream[UUID]) =
         val dao = daoFactory.newImagedMomentDAO()
         (
             () => dao.close(),
             dao.streamVideoReferenceUuidsBetweenUpdatedDates(start, end, limit, offset)
         )
-    }
 
     def countBetweenUpdatedDates(start: Instant, end: Instant)(implicit
         ec: ExecutionContext
-    ): Future[Int] = {
+    ): Future[Int] =
         val imDao = daoFactory.newImagedMomentDAO()
         val f     = imDao.runTransaction(d => d.countBetweenUpdatedDates(start, end))
         f.onComplete(_ => imDao.close())
         f
-    }
 
     def countAllGroupByVideoReferenceUUID()(implicit ec: ExecutionContext): Future[Map[UUID, Int]] =
         exec(dao => dao.countAllByVideoReferenceUuids())
@@ -186,70 +176,60 @@ class ImagedMomentController(val daoFactory: JPADAOFactory)
     def countByVideoReferenceUuid(uuid: UUID)(implicit ec: ExecutionContext): Future[Int] =
         exec(dao => dao.countByVideoReferenceUUID(uuid))
 
-    def findByConcept(concept: String, limit: Option[Int] = None, offset: Option[Int] = None)(
-        implicit ec: ExecutionContext
-    ): Future[Iterable[ImagedMoment]] = {
+    def findByConcept(concept: String, limit: Option[Int] = None, offset: Option[Int] = None)(implicit
+        ec: ExecutionContext
+    ): Future[Iterable[ImagedMoment]] =
         val imDao = daoFactory.newImagedMomentDAO()
         val f     = imDao.runTransaction(d => d.findByConcept(concept, limit, offset).map(transform))
         f.onComplete(_ => imDao.close())
         f
-    }
 
     def streamByConcept(
         concept: String,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    ): (Closeable, java.util.stream.Stream[ImagedMomentEntity]) = {
+    ): (Closeable, java.util.stream.Stream[ImagedMomentEntity]) =
         val dao = daoFactory.newImagedMomentDAO()
         (() => dao.close(), dao.streamByConcept(concept, limit, offset))
-    }
 
-    def countByConcept(concept: String)(implicit ec: ExecutionContext): Future[Int] = {
+    def countByConcept(concept: String)(implicit ec: ExecutionContext): Future[Int] =
         val imDao = daoFactory.newImagedMomentDAO()
         val f     = imDao.runTransaction(d => d.countByConcept(concept))
         f.onComplete(_ => imDao.close())
         f
-    }
 
     def findByConceptWithImages(
         concept: String,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    )(implicit ec: ExecutionContext): Future[Iterable[ImagedMoment]] = {
+    )(implicit ec: ExecutionContext): Future[Iterable[ImagedMoment]] =
         val imDao = daoFactory.newImagedMomentDAO()
-        val f     = imDao.runTransaction(d =>
-            d.findByConceptWithImages(concept, limit, offset).map(transform)
-        )
+        val f     = imDao.runTransaction(d => d.findByConceptWithImages(concept, limit, offset).map(transform))
         f.onComplete(_ => imDao.close())
         f
-    }
 
-    def countByConceptWithImages(concept: String)(implicit ec: ExecutionContext): Future[Int] = {
+    def countByConceptWithImages(concept: String)(implicit ec: ExecutionContext): Future[Int] =
         val imDao = daoFactory.newImagedMomentDAO()
         val f     = imDao.runTransaction(d => d.countByConceptWithImages(concept))
         f.onComplete(_ => imDao.close())
         f
-    }
 
     def countModifiedBeforeDate(videoReferenceUuid: UUID, date: Instant)(implicit
         ec: ExecutionContext
-    ): Future[Int] = {
+    ): Future[Int] =
         val dao = daoFactory.newImagedMomentDAO()
         val f   = dao.runTransaction(d => d.countModifiedBeforeDate(videoReferenceUuid, date))
         f.onComplete(_ => dao.close())
         f
-    }
 
     def deleteByVideoReferenceUUID(
         videoReferenceUUID: UUID
-    )(implicit ec: ExecutionContext): Future[Int] = {
-        def fn(dao: IMDAO): Int = {
+    )(implicit ec: ExecutionContext): Future[Int] =
+        def fn(dao: IMDAO): Int =
             val moments = dao.findByVideoReferenceUUID(videoReferenceUUID)
             moments.foreach(dao.delete)
             moments.size
-        }
         exec(fn)
-    }
 
     def findByWindowRequest(
         windowRequest: WindowRequest,
@@ -263,7 +243,7 @@ class ImagedMomentController(val daoFactory: JPADAOFactory)
         timecode: Option[Timecode] = None,
         recordedDate: Option[Instant] = None,
         elapsedTime: Option[Duration] = None
-    )(implicit ec: ExecutionContext): Future[ImagedMoment] = {
+    )(implicit ec: ExecutionContext): Future[ImagedMoment] =
 
         def fn(d: IMDAO) =
             val im = ImagedMomentController.findOrCreateImagedMoment(
@@ -275,34 +255,31 @@ class ImagedMomentController(val daoFactory: JPADAOFactory)
             )
             transform(im)
         exec(fn)
-    }
 
-    /** @param imagedMoments
-      *   For your sanity, make sure that they have unique indices BEFORE creating them
-      * @param ex
-      * @return
-      */
+    /**
+     * @param imagedMoments
+     *   For your sanity, make sure that they have unique indices BEFORE creating them
+     * @param ex
+     * @return
+     */
     def create(
         imagedMoments: Seq[ImagedMomentEntity]
-    )(implicit ex: ExecutionContext): Future[Seq[ImagedMoment]] = {
+    )(implicit ex: ExecutionContext): Future[Seq[ImagedMoment]] =
         val dao     = daoFactory.newImagedMomentDAO()
         val future  = dao.runTransaction(d => imagedMoments.map(im => create(d, im)))
         val future1 = future.flatMap(xs =>
-            dao.runTransaction(d => {
-                xs.flatMap(x => Option(x.getUuid).flatMap(d.findByUUID).map(transform))
-            })
+            dao.runTransaction(d => xs.flatMap(x => Option(x.getUuid).flatMap(d.findByUUID).map(transform)))
         )
         future1.onComplete(_ => dao.close())
         future1
-    }
 
-    /** This needs to be called inside a transaction. creates a new imaged moment base on the
-      * current one
-      * @param dao
-      * @param sourceImagedMoment
-      * @return
-      */
-    def create(dao: DAO[?], sourceImagedMoment: ImagedMomentEntity): ImagedMomentEntity = {
+    /**
+     * This needs to be called inside a transaction. creates a new imaged moment base on the current one
+     * @param dao
+     * @param sourceImagedMoment
+     * @return
+     */
+    def create(dao: DAO[?], sourceImagedMoment: ImagedMomentEntity): ImagedMomentEntity =
 
         val imDao = daoFactory.newImagedMomentDAO(dao)
 
@@ -329,48 +306,43 @@ class ImagedMomentController(val daoFactory: JPADAOFactory)
         // Create new image references
         sourceImagedMoment
             .getImageReferences
-            .forEach(imageReference => {
-                if (imageReference.getUuid != null) {
+            .forEach(imageReference =>
+                if imageReference.getUuid != null then
                     log.atDebug
                         .log(
                             s"An imageReference uuid was found. Setting to null as they need to be generated in the database: ${imageReference.getUuid}"
                         )
                     imageReference.setUuid(null)
-                }
                 targetImagedMoment.addImageReference(imageReference)
 //                irDao.create(imageReference)
-            })
+            )
 
         // Create new observations
         sourceImagedMoment
             .getObservations
-            .forEach(observation => {
-                if (observation.getUuid != null) {
+            .forEach(observation =>
+                if observation.getUuid != null then
                     log.atDebug
                         .log(
                             s"An observation uuid was found. Setting to null as they need to be generated in the database: ${observation.getUuid}"
                         )
                     observation.setUuid(null)
-                }
                 // We ALWAYS set the observation timestamp to now if it's null
-                if (observation.getObservationTimestamp == null) {
-                    observation.setObservationTimestamp(Instant.now())
-                }
+                if observation.getObservationTimestamp == null then observation.setObservationTimestamp(Instant.now())
                 targetImagedMoment.addObservation(observation)
                 val associations = observation.getAssociations.asScala
                 observation.setAssociations(new util.HashSet[AssociationEntity]())
                 associations.foreach(a =>
-                    if (a.getUuid != null) {
+                    if a.getUuid != null then
                         log.atDebug
                             .log(
                                 s"An association uuid was found. Setting to null as they need to be generated in the database: ${a.getUuid}"
                             )
                         a.setUuid(null)
-                    }
                     observation.addAssociation(a)
                 )
 //                obsDao.create(observation)
-            })
+            )
 
         if sourceImagedMoment.getAncillaryDatum != null then
             val ad = sourceImagedMoment.getAncillaryDatum
@@ -383,16 +355,13 @@ class ImagedMomentController(val daoFactory: JPADAOFactory)
             .log(() => "Created " + sourceImagedMoment.getObservations.size() + " observations")
 
         targetImagedMoment
-    }
 
     def bulkMove(newVideoReferenceUuid: UUID, uuids: Seq[UUID])(implicit
         ec: ExecutionContext
-    ): Future[Int] = {
-        def fn(dao: IMDAO): Int = {
+    ): Future[Int] =
+        def fn(dao: IMDAO): Int =
             dao.moveToVideoReference(newVideoReferenceUuid, uuids)
-        }
         exec(fn)
-    }
 
     def update(
         uuid: UUID,
@@ -400,10 +369,10 @@ class ImagedMomentController(val daoFactory: JPADAOFactory)
         timecode: Option[Timecode] = None,
         recordedDate: Option[Instant] = None,
         elapsedTime: Option[Duration] = None
-    )(implicit ec: ExecutionContext) = {
+    )(implicit ec: ExecutionContext) =
 
-        def fn(dao: IMDAO): ImagedMoment = {
-            dao.findByUUID(uuid) match {
+        def fn(dao: IMDAO): ImagedMoment =
+            dao.findByUUID(uuid) match
                 case None               =>
                     throw new NotFoundInDatastoreException(
                         s"No ImageMoment with UUID of $uuid was found in the datastore"
@@ -415,65 +384,56 @@ class ImagedMomentController(val daoFactory: JPADAOFactory)
                     elapsedTime.foreach(imagedMoment.setElapsedTime)
                     // dao.update(imagedMoment)
                     transform(imagedMoment)
-            }
-        }
         exec(fn)
-    }
 
-    def updateRecordedTimestampByObservationUuid(observationUuid: UUID, recordedTimestamp: Instant)(
-        implicit ec: ExecutionContext
-    ): Future[Boolean] = {
+    def updateRecordedTimestampByObservationUuid(observationUuid: UUID, recordedTimestamp: Instant)(implicit
+        ec: ExecutionContext
+    ): Future[Boolean] =
         def fn(dao: IMDAO): Boolean =
             dao.updateRecordedTimestampByObservationUuid(observationUuid, recordedTimestamp)
         exec(fn)
-    }
 
     def updateRecordedTimestamps(videoReferenceUuid: UUID, newStartTimestamp: Instant)(implicit
         ec: ExecutionContext
-    ): Future[Iterable[ImagedMoment]] = {
-        def fn(dao: IMDAO): Iterable[ImagedMoment] = {
+    ): Future[Iterable[ImagedMoment]] =
+        def fn(dao: IMDAO): Iterable[ImagedMoment] =
             dao
                 .findByVideoReferenceUUID(videoReferenceUuid)
-                .map(im => {
-                    if (im.getElapsedTime != null) {
+                .map(im =>
+                    if im.getElapsedTime != null then
                         val newRecordedDate = newStartTimestamp.plus(im.getElapsedTime)
-                        if (newRecordedDate != im.getRecordedTimestamp) {
-                            im.setRecordedTimestamp(newRecordedDate)
-                        }
-                    }
+                        if newRecordedDate != im.getRecordedTimestamp then im.setRecordedTimestamp(newRecordedDate)
                     transform(im)
-                })
-        }
+                )
         exec(fn)
-    }
-}
 
-object ImagedMomentController {
+object ImagedMomentController:
 
     private val log = System.getLogger(getClass.getName)
 
-    /** This method will find or create (if a matching one is not found in the datastore)
-      * @param dao
-      * @param videoReferenceUUID
-      * @param timecode
-      * @param recordedDate
-      * @param elapsedTime
-      * @return
-      */
+    /**
+     * This method will find or create (if a matching one is not found in the datastore)
+     * @param dao
+     * @param videoReferenceUUID
+     * @param timecode
+     * @param recordedDate
+     * @param elapsedTime
+     * @return
+     */
     def findOrCreateImagedMoment(
         dao: ImagedMomentDAO[ImagedMomentEntity],
         videoReferenceUUID: UUID,
         timecode: Option[Timecode] = None,
         recordedDate: Option[Instant] = None,
         elapsedTime: Option[Duration] = None
-    ): ImagedMomentEntity = {
+    ): ImagedMomentEntity =
         // -- Return existing or construct a new one if no match is found
         dao.findByVideoReferenceUUIDAndIndex(
             videoReferenceUUID,
             timecode,
             elapsedTime,
             recordedDate
-        ) match {
+        ) match
             case Some(imagedMoment) => imagedMoment
             case None               =>
                 log.atDebug
@@ -490,13 +450,11 @@ object ImagedMomentController {
                 dao.create(imagedMoment)
                 dao.flush()
                 imagedMoment
-        }
-    }
 
     def findOrCreateImagedMoment(
         dao: ImagedMomentDAO[ImagedMomentEntity],
         imagedMoment: ImagedMomentEntity
-    ): ImagedMomentEntity = {
+    ): ImagedMomentEntity =
         findOrCreateImagedMoment(
             dao,
             imagedMoment.getVideoReferenceUuid,
@@ -504,5 +462,3 @@ object ImagedMomentController {
             Option(imagedMoment.getRecordedTimestamp),
             Option(imagedMoment.getElapsedTime)
         )
-    }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/IndexController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/IndexController.scala
@@ -16,15 +16,14 @@
 
 package org.mbari.annosaurus.controllers
 
+import org.mbari.annosaurus.domain.{Index, IndexUpdate}
 import org.mbari.annosaurus.repository.IndexDAO
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
 
 import java.time.Instant
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
-import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
-import org.mbari.annosaurus.domain.{Index, IndexUpdate}
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/IndexController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/IndexController.scala
@@ -26,12 +26,12 @@ import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
 import org.mbari.annosaurus.domain.{Index, IndexUpdate}
 
-/** @author
-  *   Brian Schlining
-  * @since 2019-02-08T11:00:00
-  */
-class IndexController(val daoFactory: JPADAOFactory)
-    extends BaseController[IndexEntity, IndexDAO[IndexEntity], Index] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2019-02-08T11:00:00
+ */
+class IndexController(val daoFactory: JPADAOFactory) extends BaseController[IndexEntity, IndexDAO[IndexEntity], Index]:
 
     protected type IDDAO = IndexDAO[IndexEntity]
 
@@ -39,51 +39,41 @@ class IndexController(val daoFactory: JPADAOFactory)
 
     override def transform(a: IndexEntity): Index = Index.from(a, true)
 
-    def findByVideoReferenceUUID(uuid: UUID, limit: Option[Int] = None, offset: Option[Int] = None)(
-        implicit ec: ExecutionContext
+    def findByVideoReferenceUUID(uuid: UUID, limit: Option[Int] = None, offset: Option[Int] = None)(implicit
+        ec: ExecutionContext
     ): Future[Iterable[Index]] =
         exec(d => d.findByVideoReferenceUuid(uuid, limit, offset).map(transform))
 
-    /** Updates all recordedTimestamps thave have an elapsed time using the updated video
-      * starttimestamp
-      * @param videoReferenceUuid
-      * @param newStartTimestamp
-      * @param ec
-      * @return
-      */
+    /**
+     * Updates all recordedTimestamps thave have an elapsed time using the updated video starttimestamp
+     * @param videoReferenceUuid
+     * @param newStartTimestamp
+     * @param ec
+     * @return
+     */
     def updateRecordedTimestamps(videoReferenceUuid: UUID, newStartTimestamp: Instant)(implicit
         ec: ExecutionContext
-    ): Future[Iterable[Index]] = {
-        def fn(dao: IDDAO): Iterable[Index] = {
+    ): Future[Iterable[Index]] =
+        def fn(dao: IDDAO): Iterable[Index] =
             dao
                 .findByVideoReferenceUuid(videoReferenceUuid)
-                .map(im => {
-                    if (im.getElapsedTime != null) {
+                .map(im =>
+                    if im.getElapsedTime != null then
                         val newRecordedDate = newStartTimestamp.plus(im.getElapsedTime)
-                        if (newRecordedDate != im.getRecordedTimestamp) {
-                            im.setRecordedTimestamp(newRecordedDate)
-                        }
-                    }
+                        if newRecordedDate != im.getRecordedTimestamp then im.setRecordedTimestamp(newRecordedDate)
                     transform(im)
-                })
-        }
+                )
         exec(fn)
-    }
 
     def bulkUpdateRecordedTimestamps(
         imagedMoments: Iterable[IndexUpdate]
-    )(implicit ec: ExecutionContext): Future[Iterable[Index]] = {
-        def fn(dao: IDDAO): Iterable[Index] = {
-            for {
+    )(implicit ec: ExecutionContext): Future[Iterable[Index]] =
+        def fn(dao: IDDAO): Iterable[Index] =
+            for
                 im <- imagedMoments
                 rt <- im.recordedTimestamp
                 i  <- dao.findByUUID(im.uuid)
-            } yield {
+            yield
                 i.setRecordedTimestamp(rt)
                 transform(i)
-            }
-        }
         exec(fn)
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ObservationController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ObservationController.scala
@@ -27,14 +27,15 @@ import org.mbari.annosaurus.repository.jpa.entity.{ImagedMomentEntity, Observati
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.domain.{ImagedMoment, Observation}
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-25T20:33:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-25T20:33:00
+ */
 class ObservationController(
     val daoFactory: JPADAOFactory,
     bus: Subject[Any] = MessageBus.RxSubject
-) extends BaseController[ObservationEntity, ObservationDAO[ObservationEntity], Observation] {
+) extends BaseController[ObservationEntity, ObservationDAO[ObservationEntity], Observation]:
 
     type ODAO = ObservationDAO[ObservationEntity]
 
@@ -52,11 +53,11 @@ class ObservationController(
         duration: Option[Duration] = None,
         group: Option[String] = None,
         activity: Option[String] = None
-    )(implicit ec: ExecutionContext): Future[Observation] = {
+    )(implicit ec: ExecutionContext): Future[Observation] =
 
-        def fn(dao: ODAO): Observation = {
+        def fn(dao: ODAO): Observation =
             val imDao = daoFactory.newImagedMomentDAO(dao)
-            imDao.findByUUID(imagedMomentUUID) match {
+            imDao.findByUUID(imagedMomentUUID) match
                 case None               =>
                     throw new NotFoundInDatastoreException(
                         s"ImagedMoment with UUID of $imagedMomentUUID not found"
@@ -75,11 +76,8 @@ class ObservationController(
                     // observation.setImagedMoment(imagedMoment)
                     annotationPublisher.publish(Observation.from(observation))
                     transform(observation)
-            }
-        }
 
         exec(fn)
-    }
 
     def update(
         uuid: UUID,
@@ -90,160 +88,136 @@ class ObservationController(
         group: Option[String] = None,
         activity: Option[String] = None,
         imagedMomentUUID: Option[UUID] = None
-    )(implicit ec: ExecutionContext): Future[Option[Observation]] = {
+    )(implicit ec: ExecutionContext): Future[Option[Observation]] =
 
-        def fn(dao: ODAO): Option[Observation] = {
+        def fn(dao: ODAO): Option[Observation] =
             // --- 1. Does uuid exist?
             val observation = dao.findByUUID(uuid)
 
-            observation.map(obs => {
+            observation.map(obs =>
                 concept.foreach(obs.setConcept)
                 observer.foreach(obs.setObserver)
                 obs.setObservationTimestamp(observationDate)
                 duration.foreach(obs.setDuration)
                 group.foreach(obs.setGroup)
                 activity.foreach(obs.setActivity)
-                for {
+                for
                     imUUID <- imagedMomentUUID
                     imDao   = daoFactory.newImagedMomentDAO(dao)
                     newIm  <- imDao.findByUUID(imUUID)
-                } {
+                do
                     obs.getImagedMoment.removeObservation(obs)
                     newIm.addObservation(obs)
-                }
 
                 annotationPublisher.publish(Observation.from(obs))
                 transform(obs)
-            })
-        }
+            )
 
         exec(fn)
 
-    }
-
-    def findAllConcepts(implicit ec: ExecutionContext): Future[Iterable[String]] = {
+    def findAllConcepts(implicit ec: ExecutionContext): Future[Iterable[String]] =
         def fn(dao: ODAO): Iterable[String] = dao.findAllConcepts()
         exec(fn)
-    }
 
-    def findAllGroups(implicit ec: ExecutionContext): Future[Iterable[String]] = {
+    def findAllGroups(implicit ec: ExecutionContext): Future[Iterable[String]] =
         def fn(dao: ODAO): Iterable[String] = dao.findAllGroups()
         exec(fn)
-    }
 
-    def findAllActivities(implicit ec: ExecutionContext): Future[Iterable[String]] = {
+    def findAllActivities(implicit ec: ExecutionContext): Future[Iterable[String]] =
         def fn(dao: ODAO): Iterable[String] = dao.findAllActivities()
         exec(fn)
-    }
 
     def findAllConceptsByVideoReferenceUuid(
         uuid: UUID
-    )(implicit ec: ExecutionContext): Future[Iterable[String]] = {
+    )(implicit ec: ExecutionContext): Future[Iterable[String]] =
         def fn(dao: ODAO): Iterable[String] = dao.findAllConceptsByVideoReferenceUUID(uuid)
         exec(fn)
-    }
 
-    def findByVideoReferenceUuid(uuid: UUID, limit: Option[Int] = None, offset: Option[Int] = None)(
-        implicit ec: ExecutionContext
-    ): Future[Iterable[Observation]] = {
+    def findByVideoReferenceUuid(uuid: UUID, limit: Option[Int] = None, offset: Option[Int] = None)(implicit
+        ec: ExecutionContext
+    ): Future[Iterable[Observation]] =
         def fn(dao: ODAO): Iterable[Observation] =
             dao.findByVideoReferenceUuid(uuid, limit, offset).map(transform)
         exec(fn)
-    }
 
     def findByAssociationUuid(
         uuid: UUID
-    )(implicit ec: ExecutionContext): Future[Option[Observation]] = {
-        def fn(dao: ODAO): Option[Observation] = {
+    )(implicit ec: ExecutionContext): Future[Option[Observation]] =
+        def fn(dao: ODAO): Option[Observation] =
             val adao = daoFactory.newAssociationDAO(dao)
             adao.findByUUID(uuid).map(_.getObservation).map(transform)
-        }
         exec(fn)
-    }
 
-    /** This controller will also delete the [[MutableImagedMoment]] if it is empty (i.e. no
-      * observations or other imageReferences)
-      *
-      * @param uuid
-      * @param ec
-      * @return
-      */
-    override def delete(uuid: UUID)(implicit ec: ExecutionContext): Future[Boolean] = {
+    /**
+     * This controller will also delete the [[MutableImagedMoment]] if it is empty (i.e. no observations or other
+     * imageReferences)
+     *
+     * @param uuid
+     * @param ec
+     * @return
+     */
+    override def delete(uuid: UUID)(implicit ec: ExecutionContext): Future[Boolean] =
         def fn(dao: ODAO) = deleteFunction(dao, uuid)
         exec(fn)
-    }
 
     def deleteDuration(
         uuid: UUID
-    )(implicit ec: ExecutionContext): Future[Option[Observation]] = {
+    )(implicit ec: ExecutionContext): Future[Option[Observation]] =
         def fn(dao: ODAO): Option[Observation] =
             dao
                 .findByUUID(uuid)
-                .map(obs => {
+                .map(obs =>
                     obs.setDuration(null)
                     transform(obs)
-                })
+                )
         exec(fn)
-    }
 
-    def bulkDelete(uuids: Iterable[UUID])(implicit ec: ExecutionContext): Future[Boolean] = {
+    def bulkDelete(uuids: Iterable[UUID])(implicit ec: ExecutionContext): Future[Boolean] =
         def fn(dao: ODAO): Boolean =
             uuids.map(deleteFunction(dao, _)).toSeq.forall(b => b)
         exec(fn)
-    }
 
-    def countByConcept(concept: String)(implicit ec: ExecutionContext): Future[Int] = {
+    def countByConcept(concept: String)(implicit ec: ExecutionContext): Future[Int] =
         def fn(dao: ODAO): Int = dao.countByConcept(concept)
         exec(fn)
-    }
 
-    def countByConceptWithImages(concept: String)(implicit ec: ExecutionContext): Future[Int] = {
+    def countByConceptWithImages(concept: String)(implicit ec: ExecutionContext): Future[Int] =
         def fn(dao: ODAO): Int = dao.countByConceptWithImages(concept)
         exec(fn)
-    }
 
-    def countByVideoReferenceUuid(uuid: UUID)(implicit ec: ExecutionContext): Future[Int] = {
+    def countByVideoReferenceUuid(uuid: UUID)(implicit ec: ExecutionContext): Future[Int] =
         def fn(dao: ODAO): Int = dao.countByVideoReferenceUUID(uuid)
         exec(fn)
-    }
 
     def countByVideoReferenceUuidAndTimestamps(uuid: UUID, start: Instant, end: Instant)(implicit
         ec: ExecutionContext
-    ): Future[Int] = {
+    ): Future[Int] =
         def fn(dao: ODAO): Int = dao.countByVideoReferenceUUIDAndTimestamps(uuid, start, end)
         exec(fn)
-    }
 
     def countAllGroupByVideoReferenceUuid()(implicit ec: ExecutionContext): Future[Map[UUID, Int]] =
         exec(dao => dao.countAllByVideoReferenceUuids())
 
     def updateConcept(oldConcept: String, newConcept: String)(implicit
         ec: ExecutionContext
-    ): Future[Int] = {
+    ): Future[Int] =
         def fn(dao: ODAO): Int = dao.updateConcept(oldConcept, newConcept)
         exec(fn)
-    }
 
-    private def deleteFunction(dao: ODAO, uuid: UUID): Boolean = {
-        dao.findByUUID(uuid) match {
+    private def deleteFunction(dao: ODAO, uuid: UUID): Boolean =
+        dao.findByUUID(uuid) match
             case None              => false
             case Some(observation) =>
                 val imagedMoment = observation.getImagedMoment
                 // If this is the only observation and there are no imagerefs, delete the imagemoment
-                if (
-                    imagedMoment.getObservations.size == 1 && imagedMoment
+                if imagedMoment.getObservations.size == 1 && imagedMoment
                         .getImageReferences
                         .isEmpty
-                ) {
+                then
                     val imDao = daoFactory.newImagedMomentDAO(dao)
                     imDao.delete(imagedMoment)
-                }
                 else {
                     imagedMoment.removeObservation(observation)
                     dao.delete(observation)
                 }
                 true
-        }
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ObservationController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ObservationController.scala
@@ -216,8 +216,7 @@ class ObservationController(
                 then
                     val imDao = daoFactory.newImagedMomentDAO(dao)
                     imDao.delete(imagedMoment)
-                else {
+                else
                     imagedMoment.removeObservation(observation)
                     dao.delete(observation)
-                }
                 true

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ObservationController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/ObservationController.scala
@@ -16,16 +16,16 @@
 
 package org.mbari.annosaurus.controllers
 
-import java.time.{Duration, Instant}
-import java.util.UUID
 import io.reactivex.rxjava3.subjects.Subject
+import org.mbari.annosaurus.domain.Observation
 import org.mbari.annosaurus.messaging.{AnnotationPublisher, MessageBus}
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import org.mbari.annosaurus.repository.jpa.entity.{ImagedMomentEntity, ObservationEntity}
 import org.mbari.annosaurus.repository.{NotFoundInDatastoreException, ObservationDAO}
 
+import java.time.{Duration, Instant}
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
-import org.mbari.annosaurus.repository.jpa.entity.{ImagedMomentEntity, ObservationEntity}
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.domain.{ImagedMoment, Observation}
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.controllers
+
+import org.mbari.annosaurus.DatabaseConfig
+import org.mbari.annosaurus.domain.QueryRequest
+import org.mbari.annosaurus.repository.query.{
+    Constraint,
+    Constraints,
+    JDBC,
+    QueryResults,
+    QueryService
+}
+
+class QueryController(databaseConfig: DatabaseConfig, viewName: String) {
+
+    private lazy val queryService = new QueryService(databaseConfig, viewName)
+
+    def count(constraints: Constraints): Either[Throwable, Int] =
+        queryService.count(constraints)
+
+    def query(queryRequest: QueryRequest): Either[Throwable, QueryResults] =
+        queryService.query(queryRequest.querySelects, queryRequest.constraints)
+
+    def listColumns(): Either[Throwable, Seq[JDBC.Metadata]] =
+        queryService.jdbc.listColumnsMetadata(viewName)
+
+}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
@@ -26,7 +26,7 @@ class QueryController(databaseConfig: DatabaseConfig, viewName: String):
 
     def count(queryRequest: QueryRequest): Either[Throwable, Count] =
         for
-            query <- Query.validate(queryRequest)
+            query <- Query.validate(queryRequest, checkSelect = false)
             count <- queryService.count(query)
         yield Count(count)
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
@@ -25,12 +25,16 @@ class QueryController(databaseConfig: DatabaseConfig, viewName: String) {
     private lazy val queryService = new QueryService(databaseConfig, viewName)
 
     def count(queryRequest: QueryRequest): Either[Throwable, Count] =
-        val query = Query.from(queryRequest)
-        queryService.count(query).map(Count(_))
+        for
+            query <- Query.validate(queryRequest)
+            count <- queryService.count(query)
+        yield Count(count)
 
     def query(queryRequest: QueryRequest): Either[Throwable, QueryResults] =
-        val query = Query.from(queryRequest)
-        queryService.query(query)
+        for
+            query <- Query.validate(queryRequest)
+            results <- queryService.query(query)
+        yield results
 
     def listColumns(): Either[Throwable, Seq[JDBC.Metadata]] =
         queryService.jdbc.listColumnsMetadata(viewName)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
@@ -32,7 +32,7 @@ class QueryController(databaseConfig: DatabaseConfig, viewName: String):
 
     def query(queryRequest: QueryRequest): Either[Throwable, QueryResults] =
         for
-            query   <- Query.validate(queryRequest)
+            query   <- Query.validate(queryRequest, checkWhere = queryRequest.strict.getOrElse(false))
             results <- queryService.query(query)
         yield results
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
@@ -20,7 +20,7 @@ import org.mbari.annosaurus.DatabaseConfig
 import org.mbari.annosaurus.domain.{Count, QueryRequest}
 import org.mbari.annosaurus.repository.query.{JDBC, Query, QueryResults, QueryService}
 
-class QueryController(databaseConfig: DatabaseConfig, viewName: String) {
+class QueryController(databaseConfig: DatabaseConfig, viewName: String):
 
     private lazy val queryService = new QueryService(databaseConfig, viewName)
 
@@ -32,11 +32,9 @@ class QueryController(databaseConfig: DatabaseConfig, viewName: String) {
 
     def query(queryRequest: QueryRequest): Either[Throwable, QueryResults] =
         for
-            query <- Query.validate(queryRequest)
+            query   <- Query.validate(queryRequest)
             results <- queryService.query(query)
         yield results
 
     def listColumns(): Either[Throwable, Seq[JDBC.Metadata]] =
         queryService.jdbc.listColumnsMetadata(viewName)
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/controllers/QueryController.scala
@@ -17,24 +17,20 @@
 package org.mbari.annosaurus.controllers
 
 import org.mbari.annosaurus.DatabaseConfig
-import org.mbari.annosaurus.domain.QueryRequest
-import org.mbari.annosaurus.repository.query.{
-    Constraint,
-    Constraints,
-    JDBC,
-    QueryResults,
-    QueryService
-}
+import org.mbari.annosaurus.domain.{Count, QueryRequest}
+import org.mbari.annosaurus.repository.query.{JDBC, Query, QueryResults, QueryService}
 
 class QueryController(databaseConfig: DatabaseConfig, viewName: String) {
 
     private lazy val queryService = new QueryService(databaseConfig, viewName)
 
-    def count(constraints: Constraints): Either[Throwable, Int] =
-        queryService.count(constraints)
+    def count(queryRequest: QueryRequest): Either[Throwable, Count] =
+        val query = Query.from(queryRequest)
+        queryService.count(query).map(Count(_))
 
     def query(queryRequest: QueryRequest): Either[Throwable, QueryResults] =
-        queryService.query(queryRequest.querySelects, queryRequest.constraints)
+        val query = Query.from(queryRequest)
+        queryService.query(query)
 
     def listColumns(): Either[Throwable, Seq[JDBC.Metadata]] =
         queryService.jdbc.listColumnsMetadata(viewName)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Annotation.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Annotation.scala
@@ -16,15 +16,13 @@
 
 package org.mbari.annosaurus.domain
 
-import java.util.UUID
-import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
+import org.mbari.annosaurus.repository.jpa.entity.{ImageReferenceEntity, ImagedMomentEntity, ObservationEntity}
 import org.mbari.vcr4j.time.Timecode
-import java.time.Duration
-import java.time.Instant
-import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
+
+import java.time.{Duration, Instant}
+import java.util.UUID
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
 
 final case class Annotation(
     activity: Option[String] = None,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Annotation.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Annotation.scala
@@ -44,7 +44,7 @@ final case class Annotation(
     videoReferenceUuid: Option[UUID] = None,
     lastUpdated: Option[java.time.Instant] = None
 ) extends ToSnakeCase[AnnotationSC]
-    with ToEntity[ImagedMomentEntity] {
+    with ToEntity[ImagedMomentEntity]:
 
     lazy val elapsedTime: Option[Duration]   = elapsedTimeMillis.map(Duration.ofMillis(_))
     lazy val duration: Option[Duration]      = durationMillis.map(Duration.ofMillis(_))
@@ -100,9 +100,7 @@ final case class Annotation(
         ancillaryData.foreach(x => im.setAncillaryDatum(x.toEntity))
         im
 
-}
-
-object Annotation extends FromEntity[ObservationEntity, Annotation] {
+object Annotation extends FromEntity[ObservationEntity, Annotation]:
 
     override def from(entity: ObservationEntity, extend: Boolean = false): Annotation =
 
@@ -148,24 +146,22 @@ object Annotation extends FromEntity[ObservationEntity, Annotation] {
             Option(entity.getLastUpdatedTime).map(_.toInstant)
         )
 
-    def fromImagedMoment(entity: ImagedMomentEntity, extend: Boolean = false): Seq[Annotation] = {
+    def fromImagedMoment(entity: ImagedMomentEntity, extend: Boolean = false): Seq[Annotation] =
         entity.getObservations.asScala.map(x => from(x, extend)).toSeq
-    }
 
     def toEntities(
         annotations: Seq[Annotation],
         extend: Boolean = false
-    ): Seq[ImagedMomentEntity] = {
-
-        if (annotations.isEmpty) Nil
-        else if (annotations.size == 1) Seq(annotations.head.toEntity)
+    ): Seq[ImagedMomentEntity] =
+        if annotations.isEmpty then Nil
+        else if annotations.size == 1 then Seq(annotations.head.toEntity)
         else
             val imagedMoments = annotations.map(_.toEntity)
 
             // Consolidate imaged moments
             val imagedMomentMap   = mutable.Map[ImagedMomentEntity, Seq[ImagedMomentEntity]]()
             val imageReferenceMap = mutable.Map[ImagedMomentEntity, Seq[ImageReferenceEntity]]()
-            for (im <- imagedMoments)
+            for im <- imagedMoments
             do
                 val imOpt = imagedMomentMap.get(im)
                 imOpt match
@@ -193,10 +189,6 @@ object Annotation extends FromEntity[ObservationEntity, Annotation] {
 
             imagedMomentMap.keys.toSeq
 
-    }
-
-}
-
 final case class AnnotationSC(
     activity: Option[String] = None,
     ancillary_data: Option[CachedAncillaryDatumSC] = None,
@@ -214,7 +206,7 @@ final case class AnnotationSC(
     timecode: Option[String] = None,
     video_reference_uuid: Option[UUID] = None,
     last_udpated: Option[java.time.Instant] = None
-) extends ToCamelCase[Annotation] {
+) extends ToCamelCase[Annotation]:
 
     override def toCamelCase: Annotation =
         Annotation(
@@ -235,7 +227,6 @@ final case class AnnotationSC(
             video_reference_uuid,
             last_udpated
         )
-}
 
 final case class BulkAnnotationSC(
     activity: Option[String] = None,
@@ -253,7 +244,7 @@ final case class BulkAnnotationSC(
     recorded_timestamp: Option[Instant] = None,
     timecode: Option[String] = None,
     video_reference_uuid: Option[UUID] = None
-) extends ToCamelCase[Annotation] {
+) extends ToCamelCase[Annotation]:
 
     override def toCamelCase: Annotation =
         Annotation(
@@ -273,4 +264,3 @@ final case class BulkAnnotationSC(
             timecode,
             video_reference_uuid
         )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/AnnotationCreate.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/AnnotationCreate.scala
@@ -32,9 +32,9 @@ case class AnnotationCreate(
     observer: Option[String] = None,
     recordedTimestamp: Option[Instant] = None,
     timecode: Option[String] = None
-) extends ToSnakeCase[AnnotationCreateSC] {
+) extends ToSnakeCase[AnnotationCreateSC]:
 
-    def toAnnotation: Annotation = {
+    def toAnnotation: Annotation =
         Annotation(
             activity = activity,
             concept = Some(concept),
@@ -49,9 +49,8 @@ case class AnnotationCreate(
             timecode = timecode,
             videoReferenceUuid = Some(videoReferenceUuid)
         )
-    }
 
-    def toSnakeCase: AnnotationCreateSC = {
+    def toSnakeCase: AnnotationCreateSC =
         AnnotationCreateSC(
             activity = activity,
             concept = concept,
@@ -66,12 +65,9 @@ case class AnnotationCreate(
             timecode = timecode,
             video_reference_uuid = videoReferenceUuid
         )
-    }
 
-}
-
-object AnnotationCreate {
-    def fromAnnotation(a: Annotation): AnnotationCreate = {
+object AnnotationCreate:
+    def fromAnnotation(a: Annotation): AnnotationCreate =
         // TODO - hack. Forcing get on concept and videoReferenceUuid
         AnnotationCreate(
             activity = a.activity,
@@ -87,8 +83,6 @@ object AnnotationCreate {
             timecode = a.timecode,
             videoReferenceUuid = a.videoReferenceUuid.get
         )
-    }
-}
 
 case class AnnotationCreateSC(
     video_reference_uuid: UUID,
@@ -103,9 +97,9 @@ case class AnnotationCreateSC(
     observer: Option[String] = None,
     recorded_timestamp: Option[Instant] = None,
     timecode: Option[String] = None
-) extends ToCamelCase[AnnotationCreate] {
+) extends ToCamelCase[AnnotationCreate]:
 
-    def toCamelCase: AnnotationCreate = {
+    def toCamelCase: AnnotationCreate =
         AnnotationCreate(
             activity = activity,
             concept = concept,
@@ -120,5 +114,3 @@ case class AnnotationCreateSC(
             timecode = timecode,
             videoReferenceUuid = video_reference_uuid
         )
-    }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/AnnotationUpdate.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/AnnotationUpdate.scala
@@ -33,13 +33,13 @@ case class AnnotationUpdate(
     durationMillis: Option[Long] = None,
     group: Option[String] = None,
     activity: Option[String] = None
-) extends ToSnakeCase[AnnotationUpdateSC] {
+) extends ToSnakeCase[AnnotationUpdateSC]:
 
     lazy val elapsedTime: Option[Duration]   = elapsedTimeMillis.map(Duration.ofMillis)
     lazy val duration: Option[Duration]      = durationMillis.map(Duration.ofMillis)
     lazy val validTimecode: Option[Timecode] = timecode.map(Timecode(_))
 
-    override def toSnakeCase: AnnotationUpdateSC = {
+    override def toSnakeCase: AnnotationUpdateSC =
         AnnotationUpdateSC(
             observationUuid,
             videoReferenceUuid,
@@ -53,9 +53,8 @@ case class AnnotationUpdate(
             group,
             activity
         )
-    }
 
-    def toAnnotation: Annotation = {
+    def toAnnotation: Annotation =
         Annotation(
             observationUuid = observationUuid,
             videoReferenceUuid = videoReferenceUuid,
@@ -69,8 +68,6 @@ case class AnnotationUpdate(
             group = group,
             activity = activity
         )
-    }
-}
 
 case class AnnotationUpdateSC(
     observation_uuid: Option[UUID] = None,
@@ -84,9 +81,9 @@ case class AnnotationUpdateSC(
     duration_millis: Option[Long] = None,
     group: Option[String] = None,
     activity: Option[String] = None
-) extends ToCamelCase[AnnotationUpdate] {
+) extends ToCamelCase[AnnotationUpdate]:
 
-    override def toCamelCase: AnnotationUpdate = {
+    override def toCamelCase: AnnotationUpdate =
         AnnotationUpdate(
             observation_uuid,
             video_reference_uuid,
@@ -100,5 +97,3 @@ case class AnnotationUpdateSC(
             group,
             activity
         )
-    }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Association.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Association.scala
@@ -31,7 +31,7 @@ case class Association(
     observationUuid: Option[UUID] = None,
     imagedMomentUuid: Option[UUID] = None
 ) extends ToSnakeCase[AssociationSC]
-    with ToEntity[AssociationEntity] {
+    with ToEntity[AssociationEntity]:
 
     def removeForeignKeys(): Association = copy(
         observationUuid = None,
@@ -51,14 +51,12 @@ case class Association(
             imagedMomentUuid
         )
 
-    override def toEntity: AssociationEntity = {
+    override def toEntity: AssociationEntity =
         val a = AssociationEntity(linkName, toConcept, linkValue, mimeType.orNull)
         uuid.foreach(a.setUuid)
         a
-    }
-}
 
-object Association extends FromEntity[AssociationEntity, Association] {
+object Association extends FromEntity[AssociationEntity, Association]:
     def from(entity: AssociationEntity, extend: Boolean = false): Association =
         val (optObs, optIm) =
             if extend then
@@ -78,7 +76,6 @@ object Association extends FromEntity[AssociationEntity, Association] {
             optObs,
             optIm
         )
-}
 
 case class AssociationSC(
     link_name: String,
@@ -89,7 +86,7 @@ case class AssociationSC(
     last_updated_time: Option[java.time.Instant] = None,
     observation_uuid: Option[UUID] = None,
     imaged_moment_uuid: Option[UUID] = None
-) extends ToCamelCase[Association] {
+) extends ToCamelCase[Association]:
 
     def toCamelCase: Association =
         Association(
@@ -102,4 +99,3 @@ case class AssociationSC(
             observation_uuid,
             imaged_moment_uuid
         )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Association.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Association.scala
@@ -17,9 +17,9 @@
 package org.mbari.annosaurus.domain
 
 import org.mbari.annosaurus.repository.jpa.entity.AssociationEntity
-import java.util.UUID
 import org.mbari.annosaurus.repository.jpa.entity.extensions.*
-import scala.util.Try
+
+import java.util.UUID
 
 case class Association(
     linkName: String,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Authorization.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Authorization.scala
@@ -16,19 +16,14 @@
 
 package org.mbari.annosaurus.domain
 
-final case class Authorization(tokenType: String, accessToken: String)
-    extends ToSnakeCase[AuthorizationSC] {
+final case class Authorization(tokenType: String, accessToken: String) extends ToSnakeCase[AuthorizationSC]:
     override def toSnakeCase: AuthorizationSC = AuthorizationSC(tokenType, accessToken)
-}
 
-final case class AuthorizationSC(token_type: String, access_token: String)
-    extends ToCamelCase[Authorization] {
+final case class AuthorizationSC(token_type: String, access_token: String) extends ToCamelCase[Authorization]:
     override def toCamelCase: Authorization = Authorization(token_type, access_token)
-}
 
-object Authorization {
+object Authorization:
     val TokenTypeBearer: String = "Bearer"
     val TokenTypeApiKey: String = "APIKey"
 
     def bearer(accessToken: String): Authorization = Authorization(TokenTypeBearer, accessToken)
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/CachedAncillaryDatum.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/CachedAncillaryDatum.scala
@@ -16,12 +16,11 @@
 
 package org.mbari.annosaurus.domain
 
-import java.util.UUID
-import org.mbari.annosaurus.repository.jpa.entity.{AncillaryDatumDTO, CachedAncillaryDatumEntity}
+import org.mbari.annosaurus.domain.extensions.*
 import org.mbari.annosaurus.repository.jpa.entity.extensions.*
+import org.mbari.annosaurus.repository.jpa.entity.{AncillaryDatumDTO, CachedAncillaryDatumEntity}
 
-import scala.jdk.OptionConverters.*
-import extensions.*
+import java.util.UUID
 
 final case class CachedAncillaryDatum(
     latitude: Option[Double] = None,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/CachedAncillaryDatum.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/CachedAncillaryDatum.scala
@@ -46,7 +46,7 @@ final case class CachedAncillaryDatum(
     imagedMomentUuid: Option[UUID] = None,              // extend
     recordedTimestamp: Option[java.time.Instant] = None // extend
 ) extends ToSnakeCase[CachedAncillaryDatumSC]
-    with ToEntity[CachedAncillaryDatumEntity] {
+    with ToEntity[CachedAncillaryDatumEntity]:
 
     def removeForeignKeys(): CachedAncillaryDatum =
         copy(imagedMomentUuid = None, recordedTimestamp = None, lastUpdated = None)
@@ -100,16 +100,13 @@ final case class CachedAncillaryDatum(
         // NOTE: We can't set he lastUpdated field because it's set by the database driver
         entity
 
-}
-
-object CachedAncillaryDatum extends FromEntity[CachedAncillaryDatumEntity, CachedAncillaryDatum] {
+object CachedAncillaryDatum extends FromEntity[CachedAncillaryDatumEntity, CachedAncillaryDatum]:
     def from(entity: CachedAncillaryDatumEntity, extend: Boolean = false): CachedAncillaryDatum =
         val opt =
             if extend && entity.getImagedMoment != null then entity.getImagedMoment.primaryKey
             else None
         val rt  =
-            if extend && entity.getImagedMoment != null then
-                Option(entity.getImagedMoment.getRecordedTimestamp)
+            if extend && entity.getImagedMoment != null then Option(entity.getImagedMoment.getRecordedTimestamp)
             else None
         CachedAncillaryDatum(
             entity.getLatitude.toOption,
@@ -160,8 +157,6 @@ object CachedAncillaryDatum extends FromEntity[CachedAncillaryDatumEntity, Cache
             Option(dto.recordedTimestamp)
         )
 
-}
-
 final case class CachedAncillaryDatumSC(
     latitude: Option[Double] = None,
     longitude: Option[Double] = None,
@@ -184,7 +179,7 @@ final case class CachedAncillaryDatumSC(
     last_updated_time: Option[java.time.Instant] = None,
     imaged_moment_uuid: Option[UUID] = None,
     recorded_timestamp: Option[java.time.Instant] = None
-) extends ToCamelCase[CachedAncillaryDatum] {
+) extends ToCamelCase[CachedAncillaryDatum]:
     override def toCamelCase: CachedAncillaryDatum =
         CachedAncillaryDatum(
             latitude,
@@ -209,4 +204,3 @@ final case class CachedAncillaryDatumSC(
             imaged_moment_uuid,
             recorded_timestamp
         )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/CachedVideoReferenceInfo.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/CachedVideoReferenceInfo.scala
@@ -16,10 +16,10 @@
 
 package org.mbari.annosaurus.domain
 
-import java.util.UUID
 import org.mbari.annosaurus.repository.jpa.entity.CachedVideoReferenceInfoEntity
 import org.mbari.annosaurus.repository.jpa.entity.extensions.*
-import org.mbari.annosaurus.domain.FromEntity
+
+import java.util.UUID
 
 final case class CachedVideoReferenceInfo(
     uuid: UUID,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/CachedVideoReferenceInfo.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/CachedVideoReferenceInfo.scala
@@ -29,7 +29,7 @@ final case class CachedVideoReferenceInfo(
     missionContact: Option[String] = None,
     lastUpdated: Option[java.time.Instant] = None
 ) extends ToSnakeCase[CachedVideoReferenceInfoSC]
-    with ToEntity[CachedVideoReferenceInfoEntity] {
+    with ToEntity[CachedVideoReferenceInfoEntity]:
     override def toSnakeCase: CachedVideoReferenceInfoSC = CachedVideoReferenceInfoSC(
         uuid,
         videoReferenceUuid,
@@ -39,7 +39,7 @@ final case class CachedVideoReferenceInfo(
         lastUpdated
     )
 
-    override def toEntity: CachedVideoReferenceInfoEntity = {
+    override def toEntity: CachedVideoReferenceInfoEntity =
         val entity = CachedVideoReferenceInfoEntity(
             videoReferenceUuid,
             missionId.orNull,
@@ -48,15 +48,12 @@ final case class CachedVideoReferenceInfo(
         )
         entity.setUuid(uuid)
         entity
-    }
-}
 
-object CachedVideoReferenceInfo
-    extends FromEntity[CachedVideoReferenceInfoEntity, CachedVideoReferenceInfo] {
+object CachedVideoReferenceInfo extends FromEntity[CachedVideoReferenceInfoEntity, CachedVideoReferenceInfo]:
     override def from(
         entity: CachedVideoReferenceInfoEntity,
         extend: Boolean = false
-    ): CachedVideoReferenceInfo = {
+    ): CachedVideoReferenceInfo =
         CachedVideoReferenceInfo(
             entity.getUuid,
             entity.getVideoReferenceUuid,
@@ -65,8 +62,6 @@ object CachedVideoReferenceInfo
             Option(entity.getMissionContact),
             entity.lastUpdated
         )
-    }
-}
 
 final case class CachedVideoReferenceInfoSC(
     uuid: UUID,
@@ -75,7 +70,7 @@ final case class CachedVideoReferenceInfoSC(
     mission_id: Option[String] = None,
     mission_contact: Option[String] = None,
     last_updated: Option[java.time.Instant] = None
-) extends ToCamelCase[CachedVideoReferenceInfo] {
+) extends ToCamelCase[CachedVideoReferenceInfo]:
     override def toCamelCase: CachedVideoReferenceInfo = CachedVideoReferenceInfo(
         uuid,
         video_reference_uuid,
@@ -84,7 +79,6 @@ final case class CachedVideoReferenceInfoSC(
         mission_contact,
         last_updated
     )
-}
 
 final case class CachedVideoReferenceInfoCreateSC(
     video_reference_uuid: UUID,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ConceptAssociation.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ConceptAssociation.scala
@@ -29,7 +29,7 @@ final case class ConceptAssociation(
     linkValue: String,
     mimeType: String
 ) extends ToSnakeCase[ConceptAssociationSC]
-    with ToEntity[AssociationEntity] {
+    with ToEntity[AssociationEntity]:
     def toSnakeCase: ConceptAssociationSC = ConceptAssociationSC(
         uuid,
         videoReferenceUuid,
@@ -40,15 +40,13 @@ final case class ConceptAssociation(
         mimeType
     )
 
-    override def toEntity: AssociationEntity = {
+    override def toEntity: AssociationEntity =
         val a = AssociationEntity(linkName, toConcept, linkValue, mimeType)
         a.setUuid(uuid)
         a
-    }
-}
 
-object ConceptAssociation extends FromEntity[AssociationEntity, ConceptAssociation] {
-    def from(entity: AssociationEntity, extend: Boolean = false): ConceptAssociation = {
+object ConceptAssociation extends FromEntity[AssociationEntity, ConceptAssociation]:
+    def from(entity: AssociationEntity, extend: Boolean = false): ConceptAssociation =
         ConceptAssociation(
             entity.getUuid,
             entity.getObservation.getImagedMoment.getVideoReferenceUuid,
@@ -58,7 +56,6 @@ object ConceptAssociation extends FromEntity[AssociationEntity, ConceptAssociati
             entity.getLinkValue,
             entity.getMimeType
         )
-    }
 
     def fromDto(dto: ConceptAssociationDTO): ConceptAssociation =
         ConceptAssociation(
@@ -70,7 +67,6 @@ object ConceptAssociation extends FromEntity[AssociationEntity, ConceptAssociati
             dto.linkValue,
             dto.mimeType
         )
-}
 
 final case class ConceptAssociationSC(
     uuid: UUID,
@@ -80,7 +76,7 @@ final case class ConceptAssociationSC(
     to_concept: String,
     link_value: String,
     mime_type: String
-) extends ToCamelCase[ConceptAssociation] {
+) extends ToCamelCase[ConceptAssociation]:
     def toCamelCase: ConceptAssociation = ConceptAssociation(
         uuid,
         video_reference_uuid,
@@ -90,4 +86,3 @@ final case class ConceptAssociationSC(
         link_value,
         mime_type
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ConceptAssociation.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ConceptAssociation.scala
@@ -16,9 +16,9 @@
 
 package org.mbari.annosaurus.domain
 
+import org.mbari.annosaurus.repository.jpa.entity.{AssociationEntity, ConceptAssociationDTO}
+
 import java.util.UUID
-import org.mbari.annosaurus.repository.jpa.entity.AssociationEntity
-import org.mbari.annosaurus.repository.jpa.entity.ConceptAssociationDTO
 
 final case class ConceptAssociation(
     uuid: UUID,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ConceptAssociationRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ConceptAssociationRequest.scala
@@ -21,19 +21,17 @@ import java.util.UUID
 final case class ConceptAssociationRequest(
     videoReferenceUuids: Seq[UUID],
     linkName: String
-) extends ToSnakeCase[ConceptAssociationRequestSC] {
+) extends ToSnakeCase[ConceptAssociationRequestSC]:
     def toSnakeCase: ConceptAssociationRequestSC = ConceptAssociationRequestSC(
         videoReferenceUuids,
         linkName
     )
-}
 
 final case class ConceptAssociationRequestSC(
     video_reference_uuids: Seq[UUID],
     link_name: String
-) extends ToCamelCase[ConceptAssociationRequest] {
+) extends ToCamelCase[ConceptAssociationRequest]:
     def toCamelCase: ConceptAssociationRequest = ConceptAssociationRequest(
         video_reference_uuids,
         link_name
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ConceptAssociationResponse.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ConceptAssociationResponse.scala
@@ -19,19 +19,17 @@ package org.mbari.annosaurus.domain
 final case class ConceptAssociationResponse(
     conceptAssociationRequest: ConceptAssociationRequest,
     conceptAssociations: Seq[ConceptAssociation]
-) extends ToSnakeCase[ConceptAssociationResponseSC] {
+) extends ToSnakeCase[ConceptAssociationResponseSC]:
     def toSnakeCase: ConceptAssociationResponseSC = ConceptAssociationResponseSC(
         conceptAssociationRequest.toSnakeCase,
         conceptAssociations.map(_.toSnakeCase)
     )
-}
 
 final case class ConceptAssociationResponseSC(
     concept_association_request: ConceptAssociationRequestSC,
     concept_associations: Seq[ConceptAssociationSC]
-) extends ToCamelCase[ConceptAssociationResponse] {
+) extends ToCamelCase[ConceptAssociationResponse]:
     def toCamelCase: ConceptAssociationResponse = ConceptAssociationResponse(
         concept_association_request.toCamelCase,
         concept_associations.map(_.toCamelCase)
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ConcurrentRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ConcurrentRequest.scala
@@ -23,22 +23,20 @@ final case class ConcurrentRequest(
     startTimestamp: Instant,
     endTimestamp: Instant,
     videoReferenceUuids: Seq[UUID]
-) extends ToSnakeCase[ConcurrentRequestSC] {
+) extends ToSnakeCase[ConcurrentRequestSC]:
     def toSnakeCase: ConcurrentRequestSC = ConcurrentRequestSC(
         startTimestamp,
         endTimestamp,
         videoReferenceUuids
     )
-}
 
 final case class ConcurrentRequestSC(
     start_timestamp: Instant,
     end_timestamp: Instant,
     video_reference_uuids: Seq[UUID]
-) extends ToCamelCase[ConcurrentRequest] {
+) extends ToCamelCase[ConcurrentRequest]:
     def toCamelCase: ConcurrentRequest = ConcurrentRequest(
         start_timestamp,
         end_timestamp,
         video_reference_uuids
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/DeleteCount.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/DeleteCount.scala
@@ -26,7 +26,7 @@ final case class DeleteCount(
     observationCount: Int = 0,
     imagedMomentCount: Int = 0,
     errorMessage: Option[String] = None
-) extends ToSnakeCase[DeleteCountSC] {
+) extends ToSnakeCase[DeleteCountSC]:
     override def toSnakeCase: DeleteCountSC = DeleteCountSC(
         videoReferenceUuid,
         ancillaryDataCount,
@@ -36,7 +36,6 @@ final case class DeleteCount(
         imagedMomentCount,
         errorMessage
     )
-}
 
 final case class DeleteCountSC(
     video_reference_uuid: UUID,
@@ -46,7 +45,7 @@ final case class DeleteCountSC(
     observation_count: Int = 0,
     imaged_moment_count: Int = 0,
     error_message: Option[String] = None
-) extends ToCamelCase[DeleteCount] {
+) extends ToCamelCase[DeleteCount]:
     override def toCamelCase: DeleteCount = DeleteCount(
         video_reference_uuid,
         ancillary_data_count,
@@ -56,4 +55,3 @@ final case class DeleteCountSC(
         imaged_moment_count,
         error_message
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/DepthHistogram.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/DepthHistogram.scala
@@ -17,15 +17,13 @@
 package org.mbari.annosaurus.domain
 
 case class DepthHistogram(binsMin: List[Int], binsMax: List[Int], values: List[Int])
-    extends ToSnakeCase[DepthHistogramSC] {
+    extends ToSnakeCase[DepthHistogramSC]:
     override def toSnakeCase: DepthHistogramSC = DepthHistogramSC(binsMin, binsMax, values)
 
     def count: Int = values.sum
-}
 
 case class DepthHistogramSC(bins_min: List[Int], bins_max: List[Int], values: List[Int])
-    extends ToCamelCase[DepthHistogram] {
+    extends ToCamelCase[DepthHistogram]:
     override def toCamelCase: DepthHistogram = DepthHistogram(bins_min, bins_max, values)
 
     def count: Int = values.sum
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ErrorMsg.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ErrorMsg.scala
@@ -16,20 +16,20 @@
 
 package org.mbari.annosaurus.domain
 
-sealed trait ErrorMsg {
+sealed trait ErrorMsg:
     def message: String
     def responseCode: Int
-}
 
-/** Just a simple class used to return a JSON error response
-  * @param message
-  *   the error message
-  * @param responseCode
-  *   the HTTP response code
-  * @author
-  *   Brian Schlining
-  * @since 2021-11-23T11:00:00
-  */
+/**
+ * Just a simple class used to return a JSON error response
+ * @param message
+ *   the error message
+ * @param responseCode
+ *   the HTTP response code
+ * @author
+ *   Brian Schlining
+ * @since 2021-11-23T11:00:00
+ */
 final case class StatusMsg(message: String, responseCode: Int)          extends ErrorMsg
 final case class NotFound(message: String, responseCode: Int = 404)     extends ErrorMsg
 final case class ServerError(message: String, responseCode: Int = 500)  extends ErrorMsg

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/FromEntity.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/FromEntity.scala
@@ -18,6 +18,5 @@ package org.mbari.annosaurus.domain
 
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 
-trait FromEntity[A <: IPersistentObject, B] {
+trait FromEntity[A <: IPersistentObject, B]:
     def from(entity: A, extend: Boolean): B
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/GeographicRange.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/GeographicRange.scala
@@ -23,7 +23,7 @@ case class GeographicRange(
     maxLongitude: Double,
     minDepthMeters: Double,
     maxDepthMeters: Double
-) extends ToSnakeCase[GeographicRangeSC] {
+) extends ToSnakeCase[GeographicRangeSC]:
     def toSnakeCase: GeographicRangeSC = GeographicRangeSC(
         minLatitude,
         maxLatitude,
@@ -32,7 +32,6 @@ case class GeographicRange(
         minDepthMeters,
         maxDepthMeters
     )
-}
 
 case class GeographicRangeSC(
     min_latitude: Double,
@@ -41,7 +40,7 @@ case class GeographicRangeSC(
     max_longitude: Double,
     min_depth_meters: Double,
     max_depth_meters: Double
-) extends ToCamelCase[GeographicRange] {
+) extends ToCamelCase[GeographicRange]:
     def toCamelCase: GeographicRange = GeographicRange(
         min_latitude,
         max_latitude,
@@ -50,4 +49,3 @@ case class GeographicRangeSC(
         min_depth_meters,
         max_depth_meters
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/HealthStatus.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/HealthStatus.scala
@@ -29,9 +29,9 @@ final case class HealthStatus(
     description: String = AppConfig.Description
 )
 
-object HealthStatus {
+object HealthStatus:
 
-    def default: HealthStatus = {
+    def default: HealthStatus =
         val runtime = Runtime.getRuntime
         HealthStatus(
             jdkVersion = Runtime.version.toString,
@@ -40,5 +40,3 @@ object HealthStatus {
             maxMemory = runtime.maxMemory,
             totalMemory = runtime.totalMemory
         )
-    }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Image.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Image.scala
@@ -34,7 +34,7 @@ final case class Image(
     timecode: Option[String] = None,
     elapsedTimeMillis: Option[Long] = None,
     recordedTimestamp: Option[Instant] = None
-) extends ToSnakeCase[ImageSC] {
+) extends ToSnakeCase[ImageSC]:
     override def toSnakeCase: ImageSC = ImageSC(
         imageReferenceUuid,
         videoReferenceUuid,
@@ -50,9 +50,8 @@ final case class Image(
     )
 
     lazy val elapsedTime: Option[Duration] = elapsedTimeMillis.map(Duration.ofMillis)
-}
 
-object Image extends FromEntity[ImageReferenceEntity, Image] {
+object Image extends FromEntity[ImageReferenceEntity, Image]:
     override def from(entity: ImageReferenceEntity, extend: Boolean = false): Image =
         val im            = entity.getImagedMoment // TODO: This may be null!!
         val (tc, etm, rt) =
@@ -77,7 +76,6 @@ object Image extends FromEntity[ImageReferenceEntity, Image] {
             etm,
             rt
         )
-}
 
 final case class ImageSC(
     image_reference_uuid: UUID,
@@ -91,7 +89,7 @@ final case class ImageSC(
     timecode: Option[String] = None,
     elapsed_time_millis: Option[Long] = None,
     recorded_timestamp: Option[Instant] = None
-) extends ToCamelCase[Image] {
+) extends ToCamelCase[Image]:
     override def toCamelCase: Image = Image(
         image_reference_uuid,
         video_reference_uuid,
@@ -105,4 +103,3 @@ final case class ImageSC(
         elapsed_time_millis,
         recorded_timestamp
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Image.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Image.scala
@@ -16,11 +16,12 @@
 
 package org.mbari.annosaurus.domain
 
-import java.util.UUID
+import org.mbari.annosaurus.domain.extensions.*
+import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
+
 import java.net.URL
 import java.time.{Duration, Instant}
-import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
-import extensions.*
+import java.util.UUID
 
 final case class Image(
     imageReferenceUuid: UUID,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ImageReference.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ImageReference.scala
@@ -16,11 +16,12 @@
 
 package org.mbari.annosaurus.domain
 
-import java.util.UUID
-import java.net.URL
+import org.mbari.annosaurus.domain.extensions.*
 import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
 import org.mbari.annosaurus.repository.jpa.entity.extensions.*
-import extensions.*
+
+import java.net.URL
+import java.util.UUID
 
 case class ImageReference(
     url: URL, // TODO should this be optional to allow for partial updates?

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ImageReference.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ImageReference.scala
@@ -32,7 +32,7 @@ case class ImageReference(
     lastUpdated: Option[java.time.Instant] = None,
     imagedMomentUuid: Option[UUID] = None
 ) extends ToSnakeCase[ImageReferenceSC]
-    with ToEntity[ImageReferenceEntity] {
+    with ToEntity[ImageReferenceEntity]:
 
     def removeForeignKeys(): ImageReference =
         copy(imagedMomentUuid = None, lastUpdated = None)
@@ -58,9 +58,8 @@ case class ImageReference(
         description.foreach(entity.setDescription)
         uuid.foreach(entity.setUuid)
         entity
-}
 
-object ImageReference extends FromEntity[ImageReferenceEntity, ImageReference] {
+object ImageReference extends FromEntity[ImageReferenceEntity, ImageReference]:
     override def from(entity: ImageReferenceEntity, extend: Boolean = false): ImageReference =
         val opt = if extend then entity.getImagedMoment.primaryKey else None
         ImageReference(
@@ -73,7 +72,6 @@ object ImageReference extends FromEntity[ImageReferenceEntity, ImageReference] {
             entity.lastUpdated,
             opt
         )
-}
 
 case class ImageReferenceSC(
     url: URL,
@@ -84,7 +82,7 @@ case class ImageReferenceSC(
     uuid: Option[UUID] = None,
     last_updated_time: Option[java.time.Instant] = None,
     imaged_moment_uuid: Option[UUID] = None
-) extends ToCamelCase[ImageReference] {
+) extends ToCamelCase[ImageReference]:
     override def toCamelCase: ImageReference =
         ImageReference(
             url,
@@ -96,4 +94,3 @@ case class ImageReferenceSC(
             last_updated_time,
             imaged_moment_uuid
         )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ImageUpdateSC.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ImageUpdateSC.scala
@@ -34,9 +34,9 @@ case class ImageUpdateSC(
     description: Option[String] = None
 )
 
-object ImageUpdateSC extends FromEntity[ImageReferenceEntity, ImageUpdateSC] {
+object ImageUpdateSC extends FromEntity[ImageReferenceEntity, ImageUpdateSC]:
 
-    override def from(entity: ImageReferenceEntity, extend: Boolean = false): ImageUpdateSC = {
+    override def from(entity: ImageReferenceEntity, extend: Boolean = false): ImageUpdateSC =
         val im = entity.getImagedMoment
         ImageUpdateSC(
             video_reference_uuid = Option(im.getVideoReferenceUuid),
@@ -49,5 +49,3 @@ object ImageUpdateSC extends FromEntity[ImageReferenceEntity, ImageUpdateSC] {
             height_pixels = Option(entity.getHeight),
             description = Option(entity.getDescription)
         )
-    }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ImagedMoment.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ImagedMoment.scala
@@ -35,7 +35,7 @@ final case class ImagedMoment(
     uuid: Option[UUID] = None,
     lastUpdated: Option[java.time.Instant] = None
 ) extends ToSnakeCase[ImagedMomentSC]
-    with ToEntity[ImagedMomentEntity] {
+    with ToEntity[ImagedMomentEntity]:
 
     def removeForeignKeys(): ImagedMoment = copy(
         lastUpdated = None
@@ -68,10 +68,9 @@ final case class ImagedMoment(
         entity
 
     lazy val elapsedTime: Option[Duration] = elapsedTimeMillis.map(Duration.ofMillis)
-}
 
-object ImagedMoment extends FromEntity[ImagedMomentEntity, ImagedMoment] {
-    def from(entity: ImagedMomentEntity, extend: Boolean = false): ImagedMoment = {
+object ImagedMoment extends FromEntity[ImagedMomentEntity, ImagedMoment]:
+    def from(entity: ImagedMomentEntity, extend: Boolean = false): ImagedMoment =
 
         val observations =
             if extend && !entity.getObservations().isEmpty()
@@ -100,8 +99,6 @@ object ImagedMoment extends FromEntity[ImagedMomentEntity, ImagedMoment] {
             entity.primaryKey,
             entity.lastUpdated
         )
-    }
-}
 
 final case class ImagedMomentSC(
     video_reference_uuid: UUID,
@@ -113,7 +110,7 @@ final case class ImagedMomentSC(
     ancillary_data: Option[CachedAncillaryDatumSC] = None,
     uuid: Option[UUID] = None,
     last_updated_time: Option[java.time.Instant] = None
-) extends ToCamelCase[ImagedMoment] {
+) extends ToCamelCase[ImagedMoment]:
     override def toCamelCase: ImagedMoment =
         ImagedMoment(
             video_reference_uuid,
@@ -126,4 +123,3 @@ final case class ImagedMomentSC(
             uuid,
             last_updated_time
         )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ImagedMoment.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ImagedMoment.scala
@@ -16,12 +16,12 @@
 
 package org.mbari.annosaurus.domain
 
-import java.util.UUID
-import java.time.Duration
-import org.mbari.vcr4j.time.Timecode
-import java.time.Instant
 import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
 import org.mbari.annosaurus.repository.jpa.entity.extensions.*
+import org.mbari.vcr4j.time.Timecode
+
+import java.time.{Duration, Instant}
+import java.util.UUID
 import scala.jdk.CollectionConverters.*
 
 final case class ImagedMoment(

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Index.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Index.scala
@@ -28,7 +28,7 @@ final case class Index(
     uuid: Option[UUID] = None,
     lastUpdated: Option[java.time.Instant] = None
 ) extends ToSnakeCase[IndexSC]
-    with ToEntity[IndexEntity] {
+    with ToEntity[IndexEntity]:
 
     lazy val elapsedTime              = elapsedTimeMillis.map(java.time.Duration.ofMillis)
     override def toSnakeCase: IndexSC =
@@ -41,7 +41,7 @@ final case class Index(
             lastUpdated
         )
 
-    override def toEntity: IndexEntity = {
+    override def toEntity: IndexEntity =
         val entity = new IndexEntity
         entity.setVideoReferenceUuid(videoReferenceUuid)
         timecode.foreach(tc => entity.setTimecode(org.mbari.vcr4j.time.Timecode(tc)))
@@ -49,11 +49,9 @@ final case class Index(
         recordedTimestamp.foreach(entity.setRecordedTimestamp)
         uuid.foreach(entity.setUuid)
         entity
-    }
-}
 
-object Index extends FromEntity[IndexEntity, Index] {
-    def from(entity: IndexEntity, extend: Boolean = false): Index = {
+object Index extends FromEntity[IndexEntity, Index]:
+    def from(entity: IndexEntity, extend: Boolean = false): Index =
         Index(
             entity.getVideoReferenceUuid,
             Option(entity.getTimecode).map(_.toString()),
@@ -62,9 +60,8 @@ object Index extends FromEntity[IndexEntity, Index] {
             entity.primaryKey,
             entity.lastUpdated
         )
-    }
 
-    def fromImagedMomentEntity(entity: ImagedMomentEntity): Index = {
+    def fromImagedMomentEntity(entity: ImagedMomentEntity): Index =
         Index(
             entity.getVideoReferenceUuid,
             Option(entity.getTimecode).map(_.toString()),
@@ -73,8 +70,6 @@ object Index extends FromEntity[IndexEntity, Index] {
             entity.primaryKey,
             entity.lastUpdated
         )
-    }
-}
 
 final case class IndexSC(
     video_reference_uuid: UUID,
@@ -83,7 +78,7 @@ final case class IndexSC(
     recorded_timestamp: Option[java.time.Instant] = None,
     uuid: Option[UUID] = None,
     last_updated: Option[java.time.Instant] = None
-) extends ToCamelCase[Index] {
+) extends ToCamelCase[Index]:
     override def toCamelCase: Index =
         Index(
             video_reference_uuid,
@@ -93,4 +88,3 @@ final case class IndexSC(
             uuid,
             last_updated
         )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Index.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Index.scala
@@ -16,9 +16,10 @@
 
 package org.mbari.annosaurus.domain
 
-import java.util.UUID
-import org.mbari.annosaurus.repository.jpa.entity.{ImagedMomentEntity, IndexEntity}
 import org.mbari.annosaurus.repository.jpa.entity.extensions.*
+import org.mbari.annosaurus.repository.jpa.entity.{ImagedMomentEntity, IndexEntity}
+
+import java.util.UUID
 
 final case class Index(
     videoReferenceUuid: UUID,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/IndexUpdate.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/IndexUpdate.scala
@@ -23,18 +23,16 @@ case class IndexUpdate(
     timecode: Option[String] = None,
     elapsedTimeMillis: Option[Long] = None,
     recordedTimestamp: Option[java.time.Instant] = None
-) extends ToSnakeCase[IndexUpdateSC] {
+) extends ToSnakeCase[IndexUpdateSC]:
     def toSnakeCase: IndexUpdateSC =
         IndexUpdateSC(uuid, timecode, elapsedTimeMillis, recordedTimestamp)
-}
 
 case class IndexUpdateSC(
     uuid: UUID,
     timecode: Option[String] = None,
     elapsed_time_millis: Option[Long] = None,
     recorded_timestamp: Option[java.time.Instant] = None
-) extends ToCamelCase[IndexUpdate] {
+) extends ToCamelCase[IndexUpdate]:
 
     def toCamelCase: IndexUpdate =
         IndexUpdate(uuid, timecode, elapsed_time_millis, recorded_timestamp)
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/MoveImagedMoments.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/MoveImagedMoments.scala
@@ -19,25 +19,19 @@ package org.mbari.annosaurus.domain
 import java.util.UUID
 
 case class MoveImagedMoments(videoReferenceUuid: UUID, imagedMomentUuids: Seq[UUID])
-    extends ToSnakeCase[MoveImagedMomentsSC] {
+    extends ToSnakeCase[MoveImagedMomentsSC]:
 
-    def toSnakeCase: MoveImagedMomentsSC = {
+    def toSnakeCase: MoveImagedMomentsSC =
         MoveImagedMomentsSC(
             video_reference_uuid = videoReferenceUuid,
             imaged_moment_uuids = imagedMomentUuids
         )
-    }
-
-}
 
 case class MoveImagedMomentsSC(video_reference_uuid: UUID, imaged_moment_uuids: Seq[UUID])
-    extends ToCamelCase[MoveImagedMoments] {
+    extends ToCamelCase[MoveImagedMoments]:
 
-    def toCamelCase: MoveImagedMoments = {
+    def toCamelCase: MoveImagedMoments =
         MoveImagedMoments(
             videoReferenceUuid = video_reference_uuid,
             imagedMomentUuids = imaged_moment_uuids
         )
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/MultiRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/MultiRequest.scala
@@ -18,11 +18,8 @@ package org.mbari.annosaurus.domain
 
 import java.util.UUID
 
-final case class MultiRequest(videoReferenceUuids: Seq[UUID]) extends ToSnakeCase[MultiRequestSC] {
+final case class MultiRequest(videoReferenceUuids: Seq[UUID]) extends ToSnakeCase[MultiRequestSC]:
     def toSnakeCase: MultiRequestSC = MultiRequestSC(videoReferenceUuids)
-}
 
-final case class MultiRequestSC(video_reference_uuids: Seq[UUID])
-    extends ToCamelCase[MultiRequest] {
+final case class MultiRequestSC(video_reference_uuids: Seq[UUID]) extends ToCamelCase[MultiRequest]:
     def toCamelCase: MultiRequest = MultiRequest(video_reference_uuids)
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Observation.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Observation.scala
@@ -16,10 +16,11 @@
 
 package org.mbari.annosaurus.domain
 
-import java.time.{Duration, Instant}
-import java.util.UUID
 import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
 import org.mbari.annosaurus.repository.jpa.entity.extensions.*
+
+import java.time.{Duration, Instant}
+import java.util.UUID
 import scala.jdk.CollectionConverters.*
 
 final case class Observation(

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Observation.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/Observation.scala
@@ -33,7 +33,7 @@ final case class Observation(
     uuid: Option[UUID] = None,
     lastUpdated: Option[Instant] = None
 ) extends ToSnakeCase[ObservationSC]
-    with ToEntity[ObservationEntity] {
+    with ToEntity[ObservationEntity]:
     override def toSnakeCase: ObservationSC =
         ObservationSC(
             concept,
@@ -47,7 +47,7 @@ final case class Observation(
             lastUpdated
         )
 
-    override def toEntity: ObservationEntity = {
+    override def toEntity: ObservationEntity =
         val entity = new ObservationEntity
         entity.setConcept(concept)
         durationMillis.foreach(d => entity.setDuration(Duration.ofMillis(d)))
@@ -58,12 +58,10 @@ final case class Observation(
         associations.foreach(a => entity.addAssociation(a.toEntity))
         uuid.foreach(entity.setUuid)
         entity
-    }
 
     lazy val duration: Option[Duration] = durationMillis.map(Duration.ofMillis)
-}
 
-object Observation extends FromEntity[ObservationEntity, Observation] {
+object Observation extends FromEntity[ObservationEntity, Observation]:
     override def from(entity: ObservationEntity, extend: Boolean = false): Observation =
 
         // DO not extend associations here. As that would include redundant information
@@ -81,7 +79,6 @@ object Observation extends FromEntity[ObservationEntity, Observation] {
             entity.primaryKey,
             entity.lastUpdated
         )
-}
 
 final case class ObservationSC(
     concept: String,
@@ -93,7 +90,7 @@ final case class ObservationSC(
     associations: Seq[AssociationSC] = Nil,
     uuid: Option[UUID] = None,
     last_updated_time: Option[Instant] = None
-) extends ToCamelCase[Observation] {
+) extends ToCamelCase[Observation]:
     override def toCamelCase: Observation =
         Observation(
             concept,
@@ -106,4 +103,3 @@ final case class ObservationSC(
             uuid,
             last_updated_time
         )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ObservationUpdateSC.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ObservationUpdateSC.scala
@@ -27,6 +27,5 @@ case class ObservationUpdateSC(
     duration_millis: Option[Long] = None,
     observation_timestamp: Option[Instant] = None,
     imaged_moment_uuid: Option[UUID] = None
-) {
+):
     lazy val duration: Option[Duration] = duration_millis.map(Duration.ofMillis)
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ObservationsUpdate.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ObservationsUpdate.scala
@@ -18,14 +18,18 @@ package org.mbari.annosaurus.domain
 
 import java.util.UUID
 
-/**
- * Update multiple observations at once
- * @param observationUuids The UUIDs of the observations to update
- * @param concept The new concept
- * @param observer The new observer
- * @param activity The new activity
- * @param group The new group
- */
+/** Update multiple observations at once
+  * @param observationUuids
+  *   The UUIDs of the observations to update
+  * @param concept
+  *   The new concept
+  * @param observer
+  *   The new observer
+  * @param activity
+  *   The new activity
+  * @param group
+  *   The new group
+  */
 case class ObservationsUpdate(
     observationUuids: Seq[UUID],
     concept: Option[String] = None,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ObservationsUpdate.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ObservationsUpdate.scala
@@ -18,25 +18,26 @@ package org.mbari.annosaurus.domain
 
 import java.util.UUID
 
-/** Update multiple observations at once
-  * @param observationUuids
-  *   The UUIDs of the observations to update
-  * @param concept
-  *   The new concept
-  * @param observer
-  *   The new observer
-  * @param activity
-  *   The new activity
-  * @param group
-  *   The new group
-  */
+/**
+ * Update multiple observations at once
+ * @param observationUuids
+ *   The UUIDs of the observations to update
+ * @param concept
+ *   The new concept
+ * @param observer
+ *   The new observer
+ * @param activity
+ *   The new activity
+ * @param group
+ *   The new group
+ */
 case class ObservationsUpdate(
     observationUuids: Seq[UUID],
     concept: Option[String] = None,
     observer: Option[String] = None,
     activity: Option[String] = None,
     group: Option[String] = None
-) extends ToSnakeCase[ObservationsUpdateSC] {
+) extends ToSnakeCase[ObservationsUpdateSC]:
     def toSnakeCase: ObservationsUpdateSC = ObservationsUpdateSC(
         observation_uuids = observationUuids,
         concept = concept,
@@ -44,7 +45,6 @@ case class ObservationsUpdate(
         activity = activity,
         group = group
     )
-}
 
 case class ObservationsUpdateSC(
     observation_uuids: Seq[UUID],
@@ -52,7 +52,7 @@ case class ObservationsUpdateSC(
     observer: Option[String] = None,
     activity: Option[String] = None,
     group: Option[String] = None
-) extends ToCamelCase[ObservationsUpdate] {
+) extends ToCamelCase[ObservationsUpdate]:
     def toCamelCase: ObservationsUpdate = ObservationsUpdate(
         observationUuids = observation_uuids,
         concept = concept,
@@ -60,4 +60,3 @@ case class ObservationsUpdateSC(
         activity = activity,
         group = group
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryConstraints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryConstraints.scala
@@ -43,7 +43,7 @@ final case class QueryConstraints(
     missionContacts: Seq[String] = Nil,
     platformName: Option[String] = None,
     missionId: Option[String] = None
-) extends ToSnakeCase[QueryConstraintsSC] {
+) extends ToSnakeCase[QueryConstraintsSC]:
 
     // Used by Circe reify. If serializing fails, the circe codec will fall back to snake_case
     require(
@@ -55,7 +55,7 @@ final case class QueryConstraints(
     val definedOffset: Int   = offset.getOrElse(0)
     val includeData: Boolean = data.getOrElse(false)
 
-    def toSnakeCase: QueryConstraintsSC = {
+    def toSnakeCase: QueryConstraintsSC =
         QueryConstraintsSC(
             Option(videoReferenceUuids),
             Option(concepts),
@@ -79,8 +79,6 @@ final case class QueryConstraints(
             platformName,
             missionId
         )
-    }
-}
 
 final case class QueryConstraintsSC(
     video_reference_uuids: Option[Seq[UUID]] = None,
@@ -104,8 +102,8 @@ final case class QueryConstraintsSC(
     mission_contacts: Option[Seq[String]] = None,
     platform_name: Option[String] = None,
     mission_id: Option[String] = None
-) extends ToCamelCase[QueryConstraints] {
-    def toCamelCase: QueryConstraints = {
+) extends ToCamelCase[QueryConstraints]:
+    def toCamelCase: QueryConstraints =
         QueryConstraints(
             video_reference_uuids.getOrElse(Nil),
             concepts.getOrElse(Nil),
@@ -129,5 +127,3 @@ final case class QueryConstraintsSC(
             platform_name,
             mission_id
         )
-    }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryConstraints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryConstraints.scala
@@ -16,9 +16,8 @@
 
 package org.mbari.annosaurus.domain
 
-import java.util.UUID
 import java.time.Instant
-import org.mbari.annosaurus.repository.jdbc.QueryConstraintsSqlBuilder
+import java.util.UUID
 import scala.jdk.CollectionConverters.*
 
 final case class QueryConstraints(

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryConstraintsResponse.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryConstraintsResponse.scala
@@ -16,8 +16,6 @@
 
 package org.mbari.annosaurus.domain
 
-
-
 final case class QueryConstraintsResponse[A](queryConstraints: QueryConstraints, content: A):
     def toSnakeCase: QueryConstraintsResponseSC[A] =
         QueryConstraintsResponseSC(queryConstraints.toSnakeCase, content)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryConstraintsResponse.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryConstraintsResponse.scala
@@ -18,12 +18,10 @@ package org.mbari.annosaurus.domain
 
 import org.checkerframework.checker.units.qual.A
 
-final case class QueryConstraintsResponse[A](queryConstraints: QueryConstraints, content: A) {
+final case class QueryConstraintsResponse[A](queryConstraints: QueryConstraints, content: A):
     def toSnakeCase: QueryConstraintsResponseSC[A] =
         QueryConstraintsResponseSC(queryConstraints.toSnakeCase, content)
-}
 
-final case class QueryConstraintsResponseSC[A](query_constraints: QueryConstraintsSC, content: A) {
+final case class QueryConstraintsResponseSC[A](query_constraints: QueryConstraintsSC, content: A):
     def toCamelCase: QueryConstraintsResponse[A] =
         QueryConstraintsResponse(query_constraints.toCamelCase, content)
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryConstraintsResponse.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryConstraintsResponse.scala
@@ -16,7 +16,7 @@
 
 package org.mbari.annosaurus.domain
 
-import org.checkerframework.checker.units.qual.A
+
 
 final case class QueryConstraintsResponse[A](queryConstraints: QueryConstraints, content: A):
     def toSnakeCase: QueryConstraintsResponseSC[A] =

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
@@ -21,21 +21,26 @@ import org.mbari.annosaurus.repository.query.Query
 import java.time.Instant
 
 case class QueryRequest(
-                           where: Seq[ConstraintRequest],
-                           select: Option[Seq[String]] = None,
-                           limit: Option[Int] = None,
-                           offset: Option[Int] = None,
-                           concurrentObservations: Option[Boolean] = None,
-                           relatedAssociations: Option[Boolean] = None
+    where: Seq[ConstraintRequest],
+    select: Option[Seq[String]] = None,
+    limit: Option[Int] = None,
+    offset: Option[Int] = None,
+    concurrentObservations: Option[Boolean] = None,
+    relatedAssociations: Option[Boolean] = None,
+    distinct: Option[Boolean] = Some(true),
+    strict: Option[Boolean] = Some(false),
+    orderby: Option[Seq[String]] = None
 )
 
 case class ConstraintRequest(
     column: String,
-    in: Option[Seq[String]] = None,
-    like: Option[String] = None,
-    min: Option[Double] = None,
-    max: Option[Double] = None,
-    minmax: Option[Seq[Double]] = None,
     between: Option[Seq[Instant]] = None,
-    isnull: Option[Boolean] = None
+    contains: Option[String] = None,
+    equals: Option[String] = None,
+    in: Option[Seq[String]] = None,
+    isnull: Option[Boolean] = None,
+    like: Option[String] = None,
+    max: Option[Double] = None,
+    min: Option[Double] = None,
+    minmax: Option[Seq[Double]] = None
 )

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
@@ -20,23 +20,34 @@ import java.time.Instant
 
 /**
  * QueryRequest is a case class that represents a query (i.e. SQL) request.
- * @param where A list of constraints to apply to the query
- * @param select A list of columns to return
- * @param limit The maximum number of rows to return
- * @param offset The number of rows to skip before returning results
- * @param concurrentObservations Whether to include concurrent observations in the query (i.e. observations that are part of the same moment in time on a video)
- * @param relatedAssociations Whether to include related associations in the query (i.e. associations that are related to the observations in the query)
- * @param distinct Whether to return distinct rows (default is false)
- * @param strict Whether to use strict mode or to 'enhance' the query by adding additional columns useful for grouping annotations
- *               if either concurrentObservations or relatedAssociations are true, strict is set to false regardless of the value passed in.
- *               default is true
- * @param orderby A list of columns to order the results by
+ * @param where
+ *   A list of constraints to apply to the query
+ * @param select
+ *   A list of columns to return
+ * @param limit
+ *   The maximum number of rows to return
+ * @param offset
+ *   The number of rows to skip before returning results
+ * @param concurrentObservations
+ *   Whether to include concurrent observations in the query (i.e. observations that are part of the same moment in time
+ *   on a video)
+ * @param relatedAssociations
+ *   Whether to include related associations in the query (i.e. associations that are related to the observations in the
+ *   query)
+ * @param distinct
+ *   Whether to return distinct rows (default is false)
+ * @param strict
+ *   Whether to use strict mode or to 'enhance' the query by adding additional columns useful for grouping annotations
+ *   if either concurrentObservations or relatedAssociations are true, strict is set to false regardless of the value
+ *   passed in. default is true
+ * @param orderBy
+ *   A list of columns to order the results by
  */
 case class QueryRequest(
     select: Option[Seq[String]] = None,
     distinct: Option[Boolean] = None,
     where: Option[Seq[ConstraintRequest]] = None,
-    orderby: Option[Seq[String]] = None,
+    orderBy: Option[Seq[String]] = None,
     limit: Option[Int] = None,
     offset: Option[Int] = None,
     concurrentObservations: Option[Boolean] = None,
@@ -44,6 +55,21 @@ case class QueryRequest(
     strict: Option[Boolean] = None
 )
 
+/**
+ * ConstraintRequest is a case class that represents a constraint to apply to a query. It can have exactly 2 fields:
+ * column and one of the following fields: between, contains, equals, in, isnull, like, max, min, minmax.
+ * @param column The column to apply the constraint to
+ * @param between A list of two numeric, or dat2 (as iso8601) values to apply a between constraint
+ * @param contains Maps to a SQL 'LIKE' clause with the value wrapped in '%' characters
+ * @param equals A value to apply an equals constraint
+ * @param in A list of values to apply an 'IN' constraint
+ * @param isnull A boolean value to apply an 'IS NULL' constraint. If true, the constraint is 'IS NULL', if false, the
+ *               constraint is 'IS NOT NULL'
+ * @param like A value to apply a 'LIKE' constraint. You must apply the '%' characters to the value before passing it
+ * @param max The maximum value to apply a '<=' constraint
+ * @param min The minimum value to apply a '>=' constraint
+ * @param minmax A list of 2 numeric values to apply a 'BETWEEN' constraint
+ */
 case class ConstraintRequest(
     column: String,
     between: Option[Seq[Instant]] = None,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
@@ -16,8 +16,6 @@
 
 package org.mbari.annosaurus.domain
 
-import org.mbari.annosaurus.repository.query.Query
-
 import java.time.Instant
 
 case class QueryRequest(

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
@@ -18,16 +18,30 @@ package org.mbari.annosaurus.domain
 
 import java.time.Instant
 
+/**
+ * QueryRequest is a case class that represents a query (i.e. SQL) request.
+ * @param where A list of constraints to apply to the query
+ * @param select A list of columns to return
+ * @param limit The maximum number of rows to return
+ * @param offset The number of rows to skip before returning results
+ * @param concurrentObservations Whether to include concurrent observations in the query (i.e. observations that are part of the same moment in time on a video)
+ * @param relatedAssociations Whether to include related associations in the query (i.e. associations that are related to the observations in the query)
+ * @param distinct Whether to return distinct rows (default is false)
+ * @param strict Whether to use strict mode or to 'enhance' the query by adding additional columns useful for grouping annotations
+ *               if either concurrentObservations or relatedAssociations are true, strict is set to false regardless of the value passed in.
+ *               default is true
+ * @param orderby A list of columns to order the results by
+ */
 case class QueryRequest(
-    where: Seq[ConstraintRequest],
     select: Option[Seq[String]] = None,
+    distinct: Option[Boolean] = None,
+    where: Option[Seq[ConstraintRequest]] = None,
+    orderby: Option[Seq[String]] = None,
     limit: Option[Int] = None,
     offset: Option[Int] = None,
     concurrentObservations: Option[Boolean] = None,
     relatedAssociations: Option[Boolean] = None,
-    distinct: Option[Boolean] = Some(true),
-    strict: Option[Boolean] = Some(false),
-    orderby: Option[Seq[String]] = None
+    strict: Option[Boolean] = None
 )
 
 case class ConstraintRequest(

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
@@ -58,17 +58,27 @@ case class QueryRequest(
 /**
  * ConstraintRequest is a case class that represents a constraint to apply to a query. It can have exactly 2 fields:
  * column and one of the following fields: between, contains, equals, in, isnull, like, max, min, minmax.
- * @param column The column to apply the constraint to
- * @param between A list of two numeric, or dat2 (as iso8601) values to apply a between constraint
- * @param contains Maps to a SQL 'LIKE' clause with the value wrapped in '%' characters
- * @param equals A value to apply an equals constraint
- * @param in A list of values to apply an 'IN' constraint
- * @param isnull A boolean value to apply an 'IS NULL' constraint. If true, the constraint is 'IS NULL', if false, the
- *               constraint is 'IS NOT NULL'
- * @param like A value to apply a 'LIKE' constraint. You must apply the '%' characters to the value before passing it
- * @param max The maximum value to apply a '<=' constraint
- * @param min The minimum value to apply a '>=' constraint
- * @param minmax A list of 2 numeric values to apply a 'BETWEEN' constraint
+ * @param column
+ *   The column to apply the constraint to
+ * @param between
+ *   A list of two numeric, or dat2 (as iso8601) values to apply a between constraint
+ * @param contains
+ *   Maps to a SQL 'LIKE' clause with the value wrapped in '%' characters
+ * @param equals
+ *   A value to apply an equals constraint
+ * @param in
+ *   A list of values to apply an 'IN' constraint
+ * @param isnull
+ *   A boolean value to apply an 'IS NULL' constraint. If true, the constraint is 'IS NULL', if false, the constraint is
+ *   'IS NOT NULL'
+ * @param like
+ *   A value to apply a 'LIKE' constraint. You must apply the '%' characters to the value before passing it
+ * @param max
+ *   The maximum value to apply a '<=' constraint
+ * @param min
+ *   The minimum value to apply a '>=' constraint
+ * @param minmax
+ *   A list of 2 numeric values to apply a 'BETWEEN' constraint
  */
 case class ConstraintRequest(
     column: String,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.domain
+
+import org.mbari.annosaurus.repository.query.Constraints
+
+case class QueryRequest(
+    querySelects: Seq[String],
+    constraints: Constraints
+)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/QueryRequest.scala
@@ -16,9 +16,26 @@
 
 package org.mbari.annosaurus.domain
 
-import org.mbari.annosaurus.repository.query.Constraints
+import org.mbari.annosaurus.repository.query.Query
+
+import java.time.Instant
 
 case class QueryRequest(
-    querySelects: Seq[String],
-    constraints: Constraints
+                           where: Seq[ConstraintRequest],
+                           select: Option[Seq[String]] = None,
+                           limit: Option[Int] = None,
+                           offset: Option[Int] = None,
+                           concurrentObservations: Option[Boolean] = None,
+                           relatedAssociations: Option[Boolean] = None
+)
+
+case class ConstraintRequest(
+    column: String,
+    in: Option[Seq[String]] = None,
+    like: Option[String] = None,
+    min: Option[Double] = None,
+    max: Option[Double] = None,
+    minmax: Option[Seq[Double]] = None,
+    between: Option[Seq[Instant]] = None,
+    isnull: Option[Boolean] = None
 )

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/TimeHistogram.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/TimeHistogram.scala
@@ -19,15 +19,13 @@ package org.mbari.annosaurus.domain
 import java.time.Instant
 
 final case class TimeHistogram(binsMin: Seq[Instant], binsMax: Seq[Instant], values: Seq[Int])
-    extends ToSnakeCase[TimeHistogramSC] {
+    extends ToSnakeCase[TimeHistogramSC]:
     override def toSnakeCase: TimeHistogramSC = TimeHistogramSC(binsMin, binsMax, values)
 
     def count: Int = values.sum
-}
 
 final case class TimeHistogramSC(bins_min: Seq[Instant], bins_max: Seq[Instant], values: Seq[Int])
-    extends ToCamelCase[TimeHistogram] {
+    extends ToCamelCase[TimeHistogram]:
     override def toCamelCase: TimeHistogram = TimeHistogram(bins_min, bins_max, values)
 
     def count: Int = values.sum
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ToCamelCase.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ToCamelCase.scala
@@ -16,6 +16,5 @@
 
 package org.mbari.annosaurus.domain
 
-trait ToCamelCase[A] {
+trait ToCamelCase[A]:
     def toCamelCase: A
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ToEntity.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ToEntity.scala
@@ -18,6 +18,5 @@ package org.mbari.annosaurus.domain
 
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 
-trait ToEntity[A <: IPersistentObject] {
+trait ToEntity[A <: IPersistentObject]:
     def toEntity: A
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ToSnakeCase.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/ToSnakeCase.scala
@@ -16,8 +16,6 @@
 
 package org.mbari.annosaurus.domain
 
-trait ToSnakeCase[A] {
+trait ToSnakeCase[A]:
 
     def toSnakeCase: A
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/WindowRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/WindowRequest.scala
@@ -16,8 +16,8 @@
 
 package org.mbari.annosaurus.domain
 
-import java.util.UUID
 import java.time.Duration
+import java.util.UUID
 
 final case class WindowRequest(
     videoReferenceUuids: Seq[UUID],

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/WindowRequest.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/WindowRequest.scala
@@ -23,7 +23,7 @@ final case class WindowRequest(
     videoReferenceUuids: Seq[UUID],
     imagedMomentUuid: UUID,
     windowMillis: Long
-) extends ToSnakeCase[WindowRequestSC] {
+) extends ToSnakeCase[WindowRequestSC]:
     def toSnakeCase: WindowRequestSC = WindowRequestSC(
         videoReferenceUuids,
         imagedMomentUuid,
@@ -31,16 +31,14 @@ final case class WindowRequest(
     )
 
     val window: Duration = Duration.ofMillis(windowMillis)
-}
 
 final case class WindowRequestSC(
     video_reference_uuids: Seq[UUID],
     imaged_moment_uuid: UUID,
     window_millis: Long
-) extends ToCamelCase[WindowRequest] {
+) extends ToCamelCase[WindowRequest]:
     def toCamelCase: WindowRequest = WindowRequest(
         video_reference_uuids,
         imaged_moment_uuid,
         window_millis
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/domain/extensions.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/domain/extensions.scala
@@ -22,22 +22,22 @@ object extensions:
     // resulting in Option(null) returning Some(0.0) instead of None
     extension (d: java.lang.Double)
         def toOption: Option[Double] =
-            if (d == null) None
-            else if (d.isNaN) None
+            if d == null then None
+            else if d.isNaN then None
             else Some(d)
 
     extension (f: java.lang.Float)
         def toOption: Option[Float] =
-            if (f == null) None
-            else if (f.isNaN) None
+            if f == null then None
+            else if f.isNaN then None
             else Some(f)
 
     extension (i: java.lang.Integer)
         def toOption: Option[Int] =
-            if (i == null) None
+            if i == null then None
             else Some(i)
 
     extension (l: java.lang.Long)
         def toOption: Option[Long] =
-            if (l == null) None
+            if l == null then None
             else Some(l)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpoints.scala
@@ -35,16 +35,14 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 // Endpoint[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, -R]
-class AnalysisEndpoints(repository: AnalysisRepository)(implicit val executor: ExecutionContext)
-    extends Endpoints {
+class AnalysisEndpoints(repository: AnalysisRepository)(implicit val executor: ExecutionContext) extends Endpoints:
 
     private val base = "histogram"
     private val tag  = "Analysis"
 
-    val depthHistogram
-        : Endpoint[Unit, (Option[Int], QueryConstraints), ErrorMsg, QueryConstraintsResponseSC[
-            DepthHistogramSC
-        ], Any] = openEndpoint
+    val depthHistogram: Endpoint[Unit, (Option[Int], QueryConstraints), ErrorMsg, QueryConstraintsResponseSC[
+        DepthHistogramSC
+    ], Any] = openEndpoint
         .post
         .in(base / "depth")
         .in(query[Option[Int]]("size").description("Bin size in meters"))
@@ -65,10 +63,9 @@ class AnalysisEndpoints(repository: AnalysisRepository)(implicit val executor: E
             handleErrors(f)
         }
 
-    val timeHistogram
-        : Endpoint[Unit, (Option[Int], QueryConstraints), ErrorMsg, QueryConstraintsResponseSC[
-            TimeHistogramSC
-        ], Any] = openEndpoint
+    val timeHistogram: Endpoint[Unit, (Option[Int], QueryConstraints), ErrorMsg, QueryConstraintsResponseSC[
+        TimeHistogramSC
+    ], Any] = openEndpoint
         .post
         .in(base / "time")
         .in(query[Option[Int]]("size").description("Bin size in days").default(Some(50)))
@@ -91,5 +88,3 @@ class AnalysisEndpoints(repository: AnalysisRepository)(implicit val executor: E
 
     override def allImpl: List[ServerEndpoint[Any, Future]] =
         List(depthHistogramImpl, timeHistogramImpl)
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpoints.scala
@@ -24,15 +24,14 @@ import org.mbari.annosaurus.domain.{
     QueryConstraintsSC,
     TimeHistogramSC
 }
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
 import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.repository.jdbc.AnalysisRepository
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
-import CustomTapirJsonCirce.*
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 // Endpoint[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, -R]
 class AnalysisEndpoints(repository: AnalysisRepository)(implicit val executor: ExecutionContext) extends Endpoints:

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpoints.scala
@@ -17,27 +17,13 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.AnnotationController
-import org.mbari.annosaurus.domain.{
-    Annotation,
-    AnnotationCreate,
-    AnnotationCreateSC,
-    AnnotationSC,
-    AnnotationUpdateSC,
-    BulkAnnotationSC,
-    ConcurrentRequest,
-    ConcurrentRequestCountSC,
-    ConcurrentRequestSC,
-    ErrorMsg,
-    MultiRequest,
-    MultiRequestCountSC
-}
+import org.mbari.annosaurus.domain.{AnnotationCreateSC, AnnotationSC, AnnotationUpdateSC, BulkAnnotationSC, ConcurrentRequest, ConcurrentRequestCountSC, ErrorMsg, MultiRequest, MultiRequestCountSC}
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
+import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
 import sttp.tapir.*
-//import sttp.tapir.json.circe.*
 import sttp.tapir.server.ServerEndpoint
-import CustomTapirJsonCirce.*
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpoints.scala
@@ -17,7 +17,17 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.AnnotationController
-import org.mbari.annosaurus.domain.{AnnotationCreateSC, AnnotationSC, AnnotationUpdateSC, BulkAnnotationSC, ConcurrentRequest, ConcurrentRequestCountSC, ErrorMsg, MultiRequest, MultiRequestCountSC}
+import org.mbari.annosaurus.domain.{
+    AnnotationCreateSC,
+    AnnotationSC,
+    AnnotationUpdateSC,
+    BulkAnnotationSC,
+    ConcurrentRequest,
+    ConcurrentRequestCountSC,
+    ErrorMsg,
+    MultiRequest,
+    MultiRequestCountSC
+}
 import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
 import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpoints.scala
@@ -45,7 +45,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class AnnotationEndpoints(controller: AnnotationController)(using
     ec: ExecutionContext,
     jwtService: JwtService
-) extends Endpoints {
+) extends Endpoints:
 
     private val base = "annotations"
     private val tag  = "Annotations"
@@ -83,8 +83,7 @@ class AnnotationEndpoints(controller: AnnotationController)(using
                 )
             }
 
-    val findAnnotationsByVideoReferenceUuid
-        : Endpoint[Unit, (UUID, Paging), ErrorMsg, Seq[AnnotationSC], Any] =
+    val findAnnotationsByVideoReferenceUuid: Endpoint[Unit, (UUID, Paging), ErrorMsg, Seq[AnnotationSC], Any] =
         openEndpoint
             .get
             .in(base / "videoreference" / path[UUID]("videoReferenceUuid"))
@@ -108,8 +107,7 @@ class AnnotationEndpoints(controller: AnnotationController)(using
     // TOOD do we need this endpoint anymore?
 
     //    POST /
-    val createAnnotation
-        : Endpoint[Option[String], AnnotationCreateSC, ErrorMsg, AnnotationSC, Any] =
+    val createAnnotation: Endpoint[Option[String], AnnotationCreateSC, ErrorMsg, AnnotationSC, Any] =
         secureEndpoint
             .post
             .in(base)
@@ -133,8 +131,7 @@ class AnnotationEndpoints(controller: AnnotationController)(using
             }
 
 //        POST / bulk
-    val bulkCreateAnnotations
-        : Endpoint[Option[String], Seq[BulkAnnotationSC], ErrorMsg, Seq[AnnotationSC], Any] =
+    val bulkCreateAnnotations: Endpoint[Option[String], Seq[BulkAnnotationSC], ErrorMsg, Seq[AnnotationSC], Any] =
         secureEndpoint
             .post
             .in(base / "bulk")
@@ -231,8 +228,7 @@ class AnnotationEndpoints(controller: AnnotationController)(using
             }
 
 //    PUT /: uuid
-    val updateAnnotation
-        : Endpoint[Option[String], (UUID, AnnotationUpdateSC), ErrorMsg, AnnotationSC, Any] =
+    val updateAnnotation: Endpoint[Option[String], (UUID, AnnotationUpdateSC), ErrorMsg, AnnotationSC, Any] =
         secureEndpoint
             .put
             .in(base / path[UUID]("observationUuid"))
@@ -242,7 +238,7 @@ class AnnotationEndpoints(controller: AnnotationController)(using
             .description("Update an annotation. The request body can be camelCase or snake_case")
             .tag(tag)
 
-    val updateAnnotationImpl: ServerEndpoint[Any, Future] =
+    val updateAnnotationImpl: ServerEndpoint[Any, Future]                                                          =
         updateAnnotation
             .serverSecurityLogic(jwtOpt => verify(jwtOpt))
             .serverLogic { _ => (uuid, annotationCreate) =>
@@ -250,8 +246,7 @@ class AnnotationEndpoints(controller: AnnotationController)(using
                 handleOption(controller.update(uuid, annotation).map(x => x.map(_.toSnakeCase)))
             }
 //    PUT / bulk
-    val bulkUpdateAnnotations
-        : Endpoint[Option[String], Seq[AnnotationUpdateSC], ErrorMsg, Seq[AnnotationSC], Any] =
+    val bulkUpdateAnnotations: Endpoint[Option[String], Seq[AnnotationUpdateSC], ErrorMsg, Seq[AnnotationSC], Any] =
         secureEndpoint
             .put
             .in(base / "bulk")
@@ -298,4 +293,3 @@ class AnnotationEndpoints(controller: AnnotationController)(using
         updateAnnotationImpl,
         createAnnotationImpl
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AssociationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AssociationEndpoints.scala
@@ -28,13 +28,13 @@ import org.mbari.annosaurus.domain.{
     RenameConcept,
     RenameCountSC
 }
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
+import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
+import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import sttp.model.StatusCode
-import CustomTapirJsonCirce.*
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AssociationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AssociationEndpoints.scala
@@ -42,7 +42,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class AssociationEndpoints(controller: AssociationController)(using
     ec: ExecutionContext,
     jwtService: JwtService
-) extends Endpoints {
+) extends Endpoints:
 
     private val base = "associations"
     private val tag  = "Associations"
@@ -113,8 +113,7 @@ class AssociationEndpoints(controller: AssociationController)(using
         )
 
     // PUT /:uuid form or json body
-    val updateAssociation
-        : Endpoint[Option[String], (UUID, AssociationUpdateSC), ErrorMsg, AssociationSC, Any] =
+    val updateAssociation: Endpoint[Option[String], (UUID, AssociationUpdateSC), ErrorMsg, AssociationSC, Any] =
         secureEndpoint
             .put
             .in(base / path[UUID]("associationUuid"))
@@ -142,8 +141,7 @@ class AssociationEndpoints(controller: AssociationController)(using
         }
 
     // PUT /bulk json body
-    val updateAssociations
-        : Endpoint[Option[String], Seq[AssociationSC], ErrorMsg, Seq[AssociationSC], Any] =
+    val updateAssociations: Endpoint[Option[String], Seq[AssociationSC], ErrorMsg, Seq[AssociationSC], Any] =
         secureEndpoint
             .put
             .in(base / "bulk")
@@ -174,7 +172,7 @@ class AssociationEndpoints(controller: AssociationController)(using
     val deleteAssociationsImpl: ServerEndpoint[Any, Future] = deleteAssociations
         .serverSecurityLogic(jwtOpt => verify(jwtOpt))
         .serverLogic { _ => uuids =>
-            if (uuids.isEmpty) Future(Left(BadRequest("No UUIDs provided")))
+            if uuids.isEmpty then Future(Left(BadRequest("No UUIDs provided")))
             else handleErrors(controller.bulkDelete(uuids))
         }
 
@@ -249,9 +247,7 @@ class AssociationEndpoints(controller: AssociationController)(using
                 handleErrors(
                     controller
                         .findByConceptAssociationRequest(conceptAssociationRequest)
-                        .map(a => {
-                            a.toSnakeCase
-                        })
+                        .map(a => a.toSnakeCase)
                 )
             }
 
@@ -280,4 +276,3 @@ class AssociationEndpoints(controller: AssociationController)(using
         updateAssociationImpl,
         deleteAssociationImpl
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AuthorizationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AuthorizationEndpoints.scala
@@ -16,19 +16,16 @@
 
 package org.mbari.annosaurus.endpoints
 
-import org.mbari.annosaurus.domain.Authorization
+import org.mbari.annosaurus.domain.{Authorization, AuthorizationSC, BadRequest, ErrorMsg, NotFound, ServerError, Unauthorized}
 import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 import sttp.model.StatusCode
-import sttp.tapir.*
-import sttp.tapir.Endpoint
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.circe.*
 import sttp.tapir.server.ServerEndpoint
-import org.mbari.annosaurus.domain.{BadRequest, ErrorMsg, NotFound, ServerError, Unauthorized}
-import org.mbari.annosaurus.domain.AuthorizationSC
+import sttp.tapir.{Endpoint, *}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class AuthorizationEndpoints()(using ec: ExecutionContext, jwtService: JwtService) extends Endpoints:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AuthorizationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AuthorizationEndpoints.scala
@@ -30,8 +30,7 @@ import sttp.tapir.server.ServerEndpoint
 import org.mbari.annosaurus.domain.{BadRequest, ErrorMsg, NotFound, ServerError, Unauthorized}
 import org.mbari.annosaurus.domain.AuthorizationSC
 
-class AuthorizationEndpoints()(using ec: ExecutionContext, jwtService: JwtService)
-    extends Endpoints:
+class AuthorizationEndpoints()(using ec: ExecutionContext, jwtService: JwtService) extends Endpoints:
 
     private val base = "auth"
     private val tag  = "Authorization"

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AuthorizationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/AuthorizationEndpoints.scala
@@ -16,7 +16,15 @@
 
 package org.mbari.annosaurus.endpoints
 
-import org.mbari.annosaurus.domain.{Authorization, AuthorizationSC, BadRequest, ErrorMsg, NotFound, ServerError, Unauthorized}
+import org.mbari.annosaurus.domain.{
+    Authorization,
+    AuthorizationSC,
+    BadRequest,
+    ErrorMsg,
+    NotFound,
+    ServerError,
+    Unauthorized
+}
 import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
 import sttp.model.StatusCode

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/CachedAncillaryDatumEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/CachedAncillaryDatumEndpoints.scala
@@ -18,12 +18,12 @@ package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.CachedAncillaryDatumController
 import org.mbari.annosaurus.domain.{CachedAncillaryDatumSC, CountForVideoReferenceSC, ErrorMsg}
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
+import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import CustomTapirJsonCirce.*
 
 import java.time.Duration
 import java.util.UUID

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/CachedAncillaryDatumEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/CachedAncillaryDatumEndpoints.scala
@@ -32,7 +32,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class CachedAncillaryDatumEndpoints(controller: CachedAncillaryDatumController)(using
     ec: ExecutionContext,
     jwtService: JwtService
-) extends Endpoints {
+) extends Endpoints:
 
     private val base = "ancillarydata"
     private val tag  = "Ancillary Data"
@@ -53,8 +53,7 @@ class CachedAncillaryDatumEndpoints(controller: CachedAncillaryDatumController)(
             }
 
     // GET /videoreference/:uuid
-    val findDataByVideoReferenceUuid
-        : Endpoint[Unit, UUID, ErrorMsg, Seq[CachedAncillaryDatumSC], Any] = openEndpoint
+    val findDataByVideoReferenceUuid: Endpoint[Unit, UUID, ErrorMsg, Seq[CachedAncillaryDatumSC], Any] = openEndpoint
         .get
         .in(base / "videoreference" / path[UUID]("videoReferenceUuid"))
         .out(jsonBody[Seq[CachedAncillaryDatumSC]])
@@ -101,8 +100,7 @@ class CachedAncillaryDatumEndpoints(controller: CachedAncillaryDatumController)(
             }
 
     // POST / form or json body
-    val createOneDatum
-        : Endpoint[Option[String], CachedAncillaryDatumSC, ErrorMsg, CachedAncillaryDatumSC, Any] =
+    val createOneDatum: Endpoint[Option[String], CachedAncillaryDatumSC, ErrorMsg, CachedAncillaryDatumSC, Any] =
         secureEndpoint
             .post
             .in(base)
@@ -147,10 +145,9 @@ class CachedAncillaryDatumEndpoints(controller: CachedAncillaryDatumController)(
             }
 
     // PUT /merge/:uuid json body
-    val mergeManyData
-        : Endpoint[Option[String], (UUID, Seq[CachedAncillaryDatumSC], Option[Int]), ErrorMsg, Seq[
-            CachedAncillaryDatumSC
-        ], Any] = secureEndpoint
+    val mergeManyData: Endpoint[Option[String], (UUID, Seq[CachedAncillaryDatumSC], Option[Int]), ErrorMsg, Seq[
+        CachedAncillaryDatumSC
+    ], Any] = secureEndpoint
         .put
         .in(base / "merge" / path[UUID]("videoReferenceUuid"))
         .in(jsonBody[Seq[CachedAncillaryDatumSC]])
@@ -201,14 +198,14 @@ class CachedAncillaryDatumEndpoints(controller: CachedAncillaryDatumController)(
             }
 
     // DELETE /videoreference/:uuid
-    val deleteDataByVideoReferenceUuid
-        : Endpoint[Option[String], UUID, ErrorMsg, CountForVideoReferenceSC, Any] = secureEndpoint
-        .delete
-        .in(base / "videoreference" / path[UUID]("videoReferenceUuid"))
-        .out(jsonBody[CountForVideoReferenceSC])
-        .name("deleteDataByVideoReferenceUuid")
-        .description("Delete ancillary data by video reference UUID")
-        .tag(tag)
+    val deleteDataByVideoReferenceUuid: Endpoint[Option[String], UUID, ErrorMsg, CountForVideoReferenceSC, Any] =
+        secureEndpoint
+            .delete
+            .in(base / "videoreference" / path[UUID]("videoReferenceUuid"))
+            .out(jsonBody[CountForVideoReferenceSC])
+            .name("deleteDataByVideoReferenceUuid")
+            .description("Delete ancillary data by video reference UUID")
+            .tag(tag)
 
     val deleteDataByVideoReferenceUuidImpl: ServerEndpoint[Any, Future] =
         deleteDataByVideoReferenceUuid
@@ -244,4 +241,3 @@ class CachedAncillaryDatumEndpoints(controller: CachedAncillaryDatumController)(
         updateOneDatumImpl,
         createOneDatumImpl
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/CachedVideoReferenceInfoEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/CachedVideoReferenceInfoEndpoints.scala
@@ -38,7 +38,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class CachedVideoReferenceInfoEndpoints(controller: CachedVideoReferenceInfoController)(using
     ec: ExecutionContext,
     jwtService: JwtService
-) extends Endpoints {
+) extends Endpoints:
 
     private val tag  = "Video Information"
     private val base = "videoreferences"
@@ -158,8 +158,7 @@ class CachedVideoReferenceInfoEndpoints(controller: CachedVideoReferenceInfoCont
             }
 
     // GET /missioncontact/:missioncontact
-    val findByMissionContact
-        : Endpoint[Unit, String, ErrorMsg, Seq[CachedVideoReferenceInfoSC], Any] =
+    val findByMissionContact: Endpoint[Unit, String, ErrorMsg, Seq[CachedVideoReferenceInfoSC], Any] =
         openEndpoint
             .get
             .in(base / "missioncontact" / path[String]("missioncontact"))
@@ -262,7 +261,7 @@ class CachedVideoReferenceInfoEndpoints(controller: CachedVideoReferenceInfoCont
                 handleErrors(
                     controller
                         .delete(uuid)
-                        .map(b => if (b) StatusCode.NoContent else StatusCode.NotFound)
+                        .map(b => if b then StatusCode.NoContent else StatusCode.NotFound)
                 )
             }
 
@@ -293,4 +292,3 @@ class CachedVideoReferenceInfoEndpoints(controller: CachedVideoReferenceInfoCont
         createOneVideoReferenceInfoImpl,
         findAllImpl
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/CachedVideoReferenceInfoEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/CachedVideoReferenceInfoEndpoints.scala
@@ -23,14 +23,13 @@ import org.mbari.annosaurus.domain.{
     CachedVideoReferenceInfoUpdateSC,
     ErrorMsg
 }
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
+import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
-import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
+import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import sttp.model.StatusCode
-import CustomTapirJsonCirce.*
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/Endpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/Endpoints.scala
@@ -20,14 +20,14 @@ import io.circe.Printer
 import org.mbari.annosaurus.domain.*
 import org.mbari.annosaurus.etc.circe.CirceCodecs
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 import org.mbari.annosaurus.etc.jwt.JwtService
 import sttp.model.StatusCode
 import sttp.model.headers.WWWAuthenticateChallenge
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.circe.*
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.{Endpoint, *}
+import sttp.tapir.*
 
 import java.net.{URI, URL}
 import java.time.Instant

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/Endpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/Endpoints.scala
@@ -24,7 +24,7 @@ import org.mbari.annosaurus.etc.circe.CirceCodecs
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.jdk.Logging.given
-import org.mbari.annosaurus.repository.query.{Constraint, Constraints}
+import org.mbari.annosaurus.repository.query.{Constraint, Query}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -119,18 +119,19 @@ trait Endpoints:
     implicit lazy val sURL: Schema[URL]                                                 = Schema.string
     implicit lazy val sInstant: Schema[Instant]                                         = Schema.string
     implicit lazy val sBulkAnnotationSc: Schema[BulkAnnotationSC]                       = Schema.derived[BulkAnnotationSC]
-    implicit lazy val sConstraintDate: Schema[Constraint.Date]                          = Schema.derived[Constraint.Date]
-    implicit lazy val sConstraintInString: Schema[Constraint.In[String]]                =
-        Schema.derived[Constraint.In[String]]
-    implicit lazy val sConstraintLike: Schema[Constraint.Like]                          = Schema.derived[Constraint.Like]
-    implicit lazy val sConstraintMax: Schema[Constraint.Max]                            = Schema.derived[Constraint.Max]
-    implicit lazy val sConstraintMin: Schema[Constraint.Min]                            = Schema.derived[Constraint.Min]
-    implicit lazy val sConstraintMinMax: Schema[Constraint.MinMax]                      =
-        Schema.derived[Constraint.MinMax]
-    implicit lazy val sConstraintIsNull: Schema[Constraint.IsNull]                      =
-        Schema.derived[Constraint.IsNull]
-    implicit lazy val sConstraint: Schema[Constraint]                                   = Schema.string
-    implicit lazy val sConstraints: Schema[Constraints]                                 = Schema.derived[Constraints]
+//    implicit lazy val sConstraintDate: Schema[Constraint.Date]                          = Schema.derived[Constraint.Date]
+//    implicit lazy val sConstraintInString: Schema[Constraint.In[String]]                =
+//        Schema.derived[Constraint.In[String]]
+//    implicit lazy val sConstraintLike: Schema[Constraint.Like]                          = Schema.derived[Constraint.Like]
+//    implicit lazy val sConstraintMax: Schema[Constraint.Max]                            = Schema.derived[Constraint.Max]
+//    implicit lazy val sConstraintMin: Schema[Constraint.Min]                            = Schema.derived[Constraint.Min]
+//    implicit lazy val sConstraintMinMax: Schema[Constraint.MinMax]                      =
+//        Schema.derived[Constraint.MinMax]
+//    implicit lazy val sConstraintIsNull: Schema[Constraint.IsNull]                      =
+//        Schema.derived[Constraint.IsNull]
+//    implicit lazy val sConstraint: Schema[Constraint]                                   = Schema.string
+//    implicit lazy val sConstraints: Schema[Query]                                 = Schema.derived[Query]
+    implicit lazy val sConstraintRequest: Schema[ConstraintRequest]                     = Schema.derived[ConstraintRequest]
     implicit lazy val sQueryRequest: Schema[QueryRequest]                               = Schema.derived[QueryRequest]
 //    given Schema[Option[URL]]                              = Schema.string
 //    implicit lazy val sOptCAD: Schema[Option[CachedAncillaryDatumSC]]                     = Schema.derived[Option[CachedAncillaryDatumSC]]

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/Endpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/Endpoints.scala
@@ -17,29 +17,22 @@
 package org.mbari.annosaurus.endpoints
 
 import io.circe.Printer
-
-import java.net.URI
 import org.mbari.annosaurus.domain.*
 import org.mbari.annosaurus.etc.circe.CirceCodecs
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.jdk.Logging.given
-import org.mbari.annosaurus.repository.query.{Constraint, Query}
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.util.Failure
-import scala.util.Success
+import org.mbari.annosaurus.etc.jwt.JwtService
 import sttp.model.StatusCode
 import sttp.model.headers.WWWAuthenticateChallenge
-import sttp.tapir.*
-import sttp.tapir.Endpoint
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.circe.*
 import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.{Endpoint, *}
 
+import java.net.{URI, URL}
 import java.time.Instant
-import java.net.URL
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 case class Paging(offset: Option[Int] = Some(0), limit: Option[Int] = Some(100))
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/Endpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/Endpoints.scala
@@ -24,10 +24,10 @@ import org.mbari.annosaurus.etc.jdk.Loggers.given
 import org.mbari.annosaurus.etc.jwt.JwtService
 import sttp.model.StatusCode
 import sttp.model.headers.WWWAuthenticateChallenge
+import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.circe.*
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.*
 
 import java.net.{URI, URL}
 import java.time.Instant

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpoints.scala
@@ -16,7 +16,18 @@
 
 package org.mbari.annosaurus.endpoints
 
-import org.mbari.annosaurus.domain.{AnnotationSC, ConcurrentRequestSC, Count, DeleteCountSC, ErrorMsg, GeographicRangeSC, ImageSC, MultiRequestSC, QueryConstraints, QueryConstraintsResponseSC}
+import org.mbari.annosaurus.domain.{
+    AnnotationSC,
+    ConcurrentRequestSC,
+    Count,
+    DeleteCountSC,
+    ErrorMsg,
+    GeographicRangeSC,
+    ImageSC,
+    MultiRequestSC,
+    QueryConstraints,
+    QueryConstraintsResponseSC
+}
 import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
 import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpoints.scala
@@ -43,14 +43,13 @@ import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 class FastAnnotationEndpoints(jdbcRepository: JdbcRepository)(using
     ec: ExecutionContext,
     jwtService: JwtService
-) extends Endpoints {
+) extends Endpoints:
 
     private val base = "fast"
     private val tag  = "Fast Annotation Queries"
 
     // GET / limit offset
-    val findAllAnnotations
-        : Endpoint[Unit, (Paging, Option[Boolean]), ErrorMsg, Seq[AnnotationSC], Any] =
+    val findAllAnnotations: Endpoint[Unit, (Paging, Option[Boolean]), ErrorMsg, Seq[AnnotationSC], Any] =
         openEndpoint
             .get
             .in(base)
@@ -99,10 +98,9 @@ class FastAnnotationEndpoints(jdbcRepository: JdbcRepository)(using
             }
 
     // POST /georange queryconstraints json
-    val findGeoRangeByQueryConstraints
-        : Endpoint[Unit, QueryConstraints, ErrorMsg, QueryConstraintsResponseSC[
-            GeographicRangeSC
-        ], Any] =
+    val findGeoRangeByQueryConstraints: Endpoint[Unit, QueryConstraints, ErrorMsg, QueryConstraintsResponseSC[
+        GeographicRangeSC
+    ], Any] =
         openEndpoint
             .post
             .in(base / "georange")
@@ -201,8 +199,7 @@ class FastAnnotationEndpoints(jdbcRepository: JdbcRepository)(using
             }
 
     // GET /images/videoreference/:uuid
-    val findImagesByVideoReferenceUuid
-        : Endpoint[Unit, (UUID, Paging), ErrorMsg, Seq[ImageSC], Any] = openEndpoint
+    val findImagesByVideoReferenceUuid: Endpoint[Unit, (UUID, Paging), ErrorMsg, Seq[ImageSC], Any] = openEndpoint
         .get
         .in(base / "images" / "videoreference" / path[UUID]("videoReferenceUuid"))
         .in(paging)
@@ -244,8 +241,7 @@ class FastAnnotationEndpoints(jdbcRepository: JdbcRepository)(using
             }
 
     // GET /concept/:concept
-    val findAnnotationsByConcept
-        : Endpoint[Unit, (String, Paging, Option[Boolean]), ErrorMsg, Seq[AnnotationSC], Any] =
+    val findAnnotationsByConcept: Endpoint[Unit, (String, Paging, Option[Boolean]), ErrorMsg, Seq[AnnotationSC], Any] =
         openEndpoint
             .get
             .in(base / "concept" / path[String]("concept"))
@@ -355,8 +351,7 @@ class FastAnnotationEndpoints(jdbcRepository: JdbcRepository)(using
             }
 
     // GET /imagedmoments/toconcept/images/:toconcept
-    val findImagedMomentUuidsByToConcept
-        : Endpoint[Unit, (String, Paging), ErrorMsg, Seq[UUID], Any] =
+    val findImagedMomentUuidsByToConcept: Endpoint[Unit, (String, Paging), ErrorMsg, Seq[UUID], Any] =
         openEndpoint
             .get
             .in(
@@ -460,10 +455,9 @@ class FastAnnotationEndpoints(jdbcRepository: JdbcRepository)(using
             }
 
     // POST /multi limit offset multirequest json
-    val findAnnotationsByMultiRequest
-        : Endpoint[Unit, (Paging, Option[Boolean], MultiRequestSC), ErrorMsg, Seq[
-            AnnotationSC
-        ], Any] =
+    val findAnnotationsByMultiRequest: Endpoint[Unit, (Paging, Option[Boolean], MultiRequestSC), ErrorMsg, Seq[
+        AnnotationSC
+    ], Any] =
         openEndpoint
             .post
             .in(base / "multi")
@@ -531,4 +525,3 @@ class FastAnnotationEndpoints(jdbcRepository: JdbcRepository)(using
         findAllAnnotationsImpl,
         findAnnotationsByQueryConstraintsImpl
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpoints.scala
@@ -335,7 +335,9 @@ class FastAnnotationEndpoints(jdbcRepository: JdbcRepository)(using
             .in(paging)
             .out(jsonBody[Seq[UUID]])
             .name("findImageMomentUuidsByConcept")
-            .description("Find the UUIDS of image moments by concept. Only include image moments with images. Sorted by recorded timestamp.")
+            .description(
+                "Find the UUIDS of image moments by concept. Only include image moments with images. Sorted by recorded timestamp."
+            )
             .tag(tag)
 
     val findImagedMomentUuidsByConceptImpl: ServerEndpoint[Any, Future] =
@@ -363,7 +365,9 @@ class FastAnnotationEndpoints(jdbcRepository: JdbcRepository)(using
             .in(paging)
             .out(jsonBody[Seq[UUID]])
             .name("findImagedMomentUuidsByToConcept")
-            .description("Find image moment UUIDs by to concept. Only include image moments with images. Sorted by recorded timestamp.")
+            .description(
+                "Find image moment UUIDs by to concept. Only include image moments with images. Sorted by recorded timestamp."
+            )
             .tag(tag)
 
     val findImagedMomentUuidsByToConceptImpl: ServerEndpoint[Any, Future] =

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpoints.scala
@@ -16,20 +16,9 @@
 
 package org.mbari.annosaurus.endpoints
 
-import org.mbari.annosaurus.domain.{
-    AnnotationSC,
-    ConcurrentRequestSC,
-    Count,
-    DeleteCount,
-    DeleteCountSC,
-    ErrorMsg,
-    GeographicRangeSC,
-    ImageSC,
-    MultiRequestSC,
-    QueryConstraints,
-    QueryConstraintsResponseSC,
-    QueryConstraintsSC
-}
+import org.mbari.annosaurus.domain.{AnnotationSC, ConcurrentRequestSC, Count, DeleteCountSC, ErrorMsg, GeographicRangeSC, ImageSC, MultiRequestSC, QueryConstraints, QueryConstraintsResponseSC}
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
+import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.repository.jdbc.JdbcRepository
 import sttp.tapir.*
@@ -37,8 +26,6 @@ import sttp.tapir.server.ServerEndpoint
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
-import CustomTapirJsonCirce.*
-import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 
 class FastAnnotationEndpoints(jdbcRepository: JdbcRepository)(using
     ec: ExecutionContext,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/HealthEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/HealthEndpoints.scala
@@ -16,16 +16,14 @@
 
 package org.mbari.annosaurus.endpoints
 
-import scala.concurrent.ExecutionContext
-import sttp.tapir.Endpoint
-import sttp.tapir.server.ServerEndpoint
-import scala.concurrent.Future
+import org.mbari.annosaurus.domain.{ErrorMsg, HealthStatus}
+import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.circe.*
-import org.mbari.annosaurus.domain.HealthStatus
-import org.mbari.annosaurus.etc.circe.CirceCodecs.given
-import org.mbari.annosaurus.domain.ErrorMsg
+import sttp.tapir.server.ServerEndpoint
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class HealthEndpoints(using ec: ExecutionContext) extends Endpoints:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImageEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImageEndpoints.scala
@@ -36,7 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ImageEndpoints(controller: ImageController)(using
     ec: ExecutionContext,
     jwtService: JwtService
-) extends Endpoints {
+) extends Endpoints:
 
     private val base = "images"
     private val tag  = "Images"
@@ -187,4 +187,3 @@ class ImageEndpoints(controller: ImageController)(using
         updateOneImageImpl,
         createOneImageImpl
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImageEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImageEndpoints.scala
@@ -18,17 +18,16 @@ package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.ImageController
 import org.mbari.annosaurus.domain.{ErrorMsg, ImageCreateSC, ImageSC, ImageUpdateSC}
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
+import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
+import org.mbari.vcr4j.time.Timecode
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import org.mbari.vcr4j.time.Timecode
-import CustomTapirJsonCirce.*
 
-import java.net.{URI, URL, URLDecoder, URLEncoder}
-import java.nio.charset.StandardCharsets
+import java.net.URL
 import java.time.Duration
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImageReferenceEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImageReferenceEndpoints.scala
@@ -18,14 +18,13 @@ package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.ImageReferenceController
 import org.mbari.annosaurus.domain.{ErrorMsg, ImageReferenceSC}
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
+import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
 import sttp.model.StatusCode
-import sttp.tapir.Endpoint
 import sttp.tapir.*
 import sttp.tapir.server.ServerEndpoint
-import CustomTapirJsonCirce.*
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImageReferenceEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImageReferenceEndpoints.scala
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ImageReferenceEndpoints(controller: ImageReferenceController)(using
     val executor: ExecutionContext,
     jwtService: JwtService
-) extends Endpoints {
+) extends Endpoints:
 
     private val base = "imagereferences"
     private val tag  = "Image References"
@@ -107,4 +107,3 @@ class ImageReferenceEndpoints(controller: ImageReferenceController)(using
 
     override def allImpl: List[ServerEndpoint[Any, Future]] =
         List(deleteImageByUuidImpl, findImageByUuidImpl, updateImageReferenceByUuidImpl)
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpoints.scala
@@ -59,7 +59,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             .in(jsonBody[MoveImagedMoments])
             .out(jsonBody[Count])
             .name("bulkMove")
-            .description("Bulk move imaged moments to a new video reference")
+            .description("Bulk move imaged moments to a new video reference. JSON request can be camelCase or snake_case")
             .tag(tag)
 
     val bulkMoveImpl: ServerEndpoint[Any, Future] =

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpoints.scala
@@ -59,7 +59,9 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             .in(jsonBody[MoveImagedMoments])
             .out(jsonBody[Count])
             .name("bulkMove")
-            .description("Bulk move imaged moments to a new video reference. JSON request can be camelCase or snake_case")
+            .description(
+                "Bulk move imaged moments to a new video reference. JSON request can be camelCase or snake_case"
+            )
             .tag(tag)
 
     val bulkMoveImpl: ServerEndpoint[Any, Future] =

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpoints.scala
@@ -29,16 +29,16 @@ import org.mbari.annosaurus.domain.{
     VideoTimestampSC,
     WindowRequestSC
 }
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
+import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
+import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
+import org.mbari.vcr4j.time.Timecode
+import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import org.mbari.vcr4j.time.Timecode
-import org.mbari.annosaurus.etc.sdk.Futures.*
-import sttp.model.StatusCode
-import CustomTapirJsonCirce.*
 
 import java.time.{Duration, Instant}
 import java.util.UUID

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpoints.scala
@@ -47,7 +47,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ImagedMomentEndpoints(controller: ImagedMomentController)(using
     ec: ExecutionContext,
     jwtService: JwtService
-) extends Endpoints {
+) extends Endpoints:
 
     private val base = "imagedmoments"
     private val tag  = "Imaged Moments"
@@ -68,7 +68,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
         bulkMove
             .serverSecurityLogic(jwtOpt => verify(jwtOpt))
             .serverLogic(_ =>
-                moveImagedMoments => {
+                moveImagedMoments =>
                     handleErrors(
                         controller
                             .bulkMove(
@@ -77,7 +77,6 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
                             )
                             .map(n => Count(n))
                     )
-                }
             )
 
     val findAllImagedMoments: Endpoint[Unit, Paging, ErrorMsg, Seq[ImagedMomentSC], Any] =
@@ -169,8 +168,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             }
 
     // GET /find/linkname/:linkName
-    val findImagedMomentsByLinkName
-        : Endpoint[Unit, (String, Paging), ErrorMsg, Seq[ImagedMomentSC], Any] =
+    val findImagedMomentsByLinkName: Endpoint[Unit, (String, Paging), ErrorMsg, Seq[ImagedMomentSC], Any] =
         openEndpoint
             .get
             .in(base / "find" / "linkname" / path[String]("linkName"))
@@ -225,8 +223,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             }
 
     // get /concept/:name
-    val findImagedMomentsByConceptName
-        : Endpoint[Unit, (String, Paging), ErrorMsg, Seq[ImagedMomentSC], Any] =
+    val findImagedMomentsByConceptName: Endpoint[Unit, (String, Paging), ErrorMsg, Seq[ImagedMomentSC], Any] =
         openEndpoint
             .get
             .in(base / "concept" / path[String]("conceptName"))
@@ -247,8 +244,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             }
 
     // GET /concept/images/:name
-    val findImagedMomentsByConceptNameWithImages
-        : Endpoint[Unit, (String, Paging), ErrorMsg, Seq[ImagedMomentSC], Any] =
+    val findImagedMomentsByConceptNameWithImages: Endpoint[Unit, (String, Paging), ErrorMsg, Seq[ImagedMomentSC], Any] =
         openEndpoint
             .get
             .in(base / "concept" / "images" / path[String]("conceptName"))
@@ -290,8 +286,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             }
 
     // GET /concept/images/count/:name
-    val countImagedMomentsByConceptNameWithImages
-        : Endpoint[Unit, String, ErrorMsg, ConceptCount, Any] =
+    val countImagedMomentsByConceptNameWithImages: Endpoint[Unit, String, ErrorMsg, ConceptCount, Any] =
         openEndpoint
             .get
             .in(
@@ -335,8 +330,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             }
 
     // GET /modified/count/:start/:end
-    val countImagedMomentsBetweenModifiedDates
-        : Endpoint[Unit, (Instant, Instant), ErrorMsg, Count, Any] =
+    val countImagedMomentsBetweenModifiedDates: Endpoint[Unit, (Instant, Instant), ErrorMsg, Count, Any] =
         openEndpoint
             .get
             .in(
@@ -357,8 +351,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             }
 
     // GET /counts
-    val countsPerVideoReference
-        : Endpoint[Unit, Unit, ErrorMsg, Seq[CountForVideoReferenceSC], Any] =
+    val countsPerVideoReference: Endpoint[Unit, Unit, ErrorMsg, Seq[CountForVideoReferenceSC], Any] =
         openEndpoint
             .get
             .in(base / "counts")
@@ -394,8 +387,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             }
 
     // GET /videoreference/:uuid
-    val findImagdMomentsByVideoReferenceUuid
-        : Endpoint[Unit, UUID, ErrorMsg, Seq[ImagedMomentSC], Any] =
+    val findImagdMomentsByVideoReferenceUuid: Endpoint[Unit, UUID, ErrorMsg, Seq[ImagedMomentSC], Any] =
         openEndpoint
             .get
             .in(base / "videoreference" / path[UUID]("videoReferenceUuid"))
@@ -413,8 +405,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             }
 
     // GET /videoreference/modified/:uuid/:date
-    val countModifiedBeforeDate
-        : Endpoint[Unit, (UUID, Instant), ErrorMsg, CountForVideoReferenceSC, Any] =
+    val countModifiedBeforeDate: Endpoint[Unit, (UUID, Instant), ErrorMsg, CountForVideoReferenceSC, Any] =
         openEndpoint
             .get
             .in(
@@ -515,8 +506,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
             }
 
     // PUT /:uuid
-    val updateImagedMoment
-        : Endpoint[Option[String], (UUID, VideoTimestampSC), ErrorMsg, ImagedMomentSC, Any] =
+    val updateImagedMoment: Endpoint[Option[String], (UUID, VideoTimestampSC), ErrorMsg, ImagedMomentSC, Any] =
         secureEndpoint
             .put
             .in(base / path[UUID]("imagedMomentUuid"))
@@ -623,7 +613,7 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
                 handleErrors(
                     controller
                         .delete(uuid)
-                        .map(b => if (b) StatusCode.NoContent else StatusCode.NotFound)
+                        .map(b => if b then StatusCode.NoContent else StatusCode.NotFound)
                 )
             }
 
@@ -687,4 +677,3 @@ class ImagedMomentEndpoints(controller: ImagedMomentController)(using
         deleteImagedMomentImpl,
         findAllImagedMomentsImpl
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/IndexEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/IndexEndpoints.scala
@@ -17,18 +17,17 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.IndexController
-
-import scala.concurrent.{ExecutionContext, Future}
-import sttp.tapir.*
-import sttp.tapir.generic.auto.*
-import sttp.tapir.server.ServerEndpoint
-import CustomTapirJsonCirce.*
-
-import java.util.UUID
-import org.mbari.annosaurus.domain.{ErrorMsg, ImagedMoment, Index, IndexSC, IndexUpdateSC}
+import org.mbari.annosaurus.domain.{ErrorMsg, Index, IndexSC, IndexUpdateSC}
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
+import sttp.tapir.*
+import sttp.tapir.generic.auto.*
+import sttp.tapir.server.ServerEndpoint
+
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
 
 class IndexEndpoints(controller: IndexController)(using
     val executor: ExecutionContext,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/IndexEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/IndexEndpoints.scala
@@ -33,7 +33,7 @@ import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
 class IndexEndpoints(controller: IndexController)(using
     val executor: ExecutionContext,
     jwtService: JwtService
-) extends Endpoints {
+) extends Endpoints:
 
     private val base = "index"
     private val tag  = "Time Indices"
@@ -56,8 +56,7 @@ class IndexEndpoints(controller: IndexController)(using
             handleErrors(f)
         }
 
-    val bulkUpdateRecordedTimestamps
-        : Endpoint[Option[String], List[IndexUpdateSC], ErrorMsg, List[IndexSC], Any] =
+    val bulkUpdateRecordedTimestamps: Endpoint[Option[String], List[IndexUpdateSC], ErrorMsg, List[IndexSC], Any] =
         secureEndpoint
             .put
             .in(base / "tapetime")
@@ -83,5 +82,3 @@ class IndexEndpoints(controller: IndexController)(using
 
     override def allImpl: List[ServerEndpoint[Any, Future]] =
         List(findByVideoReferenceUUIDImpl, bulkUpdateRecordedTimestampsImpl)
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpoints.scala
@@ -45,7 +45,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ObservationEndpoints(controller: ObservationController, jdbcRepository: JdbcRepository)(using
     ec: ExecutionContext,
     jwtService: JwtService
-) extends Endpoints {
+) extends Endpoints:
 
     private val base = "observations"
     private val tag  = "Observations"
@@ -67,8 +67,7 @@ class ObservationEndpoints(controller: ObservationController, jdbcRepository: Jd
             }
 
     // GET /videoreference/:uuid
-    val findObservationsByVideoReferenceUuid
-        : Endpoint[Unit, (UUID, Paging), ErrorMsg, Seq[ObservationSC], Any] =
+    val findObservationsByVideoReferenceUuid: Endpoint[Unit, (UUID, Paging), ErrorMsg, Seq[ObservationSC], Any] =
         openEndpoint
             .get
             .in(base / "videoreference" / path[UUID]("videoReferenceUuid"))
@@ -237,18 +236,15 @@ class ObservationEndpoints(controller: ObservationController, jdbcRepository: Jd
     val countByVideoReferenceUuidImpl: ServerEndpoint[Any, Future] =
         countByVideoReferenceUuid
             .serverLogic { (uuid, start, end) =>
-                val f = if (start.isDefined && end.isDefined) {
-                    controller.countByVideoReferenceUuidAndTimestamps(uuid, start.get, end.get)
-                }
-                else {
-                    controller.countByVideoReferenceUuid(uuid)
-                }
+                val f =
+                    if start.isDefined && end.isDefined then
+                        controller.countByVideoReferenceUuidAndTimestamps(uuid, start.get, end.get)
+                    else controller.countByVideoReferenceUuid(uuid)
                 handleErrors(f.map(i => CountForVideoReferenceSC(uuid, i)))
             }
 
     // GET/ counts
-    val countAllGroupByVideoReferenceUuid
-        : Endpoint[Unit, Unit, ErrorMsg, Seq[CountForVideoReferenceSC], Any] =
+    val countAllGroupByVideoReferenceUuid: Endpoint[Unit, Unit, ErrorMsg, Seq[CountForVideoReferenceSC], Any] =
         openEndpoint
             .get
             .in(base / "counts")
@@ -292,8 +288,7 @@ class ObservationEndpoints(controller: ObservationController, jdbcRepository: Jd
             }
 
     // PUT /:uuid
-    val updateOneObservation
-        : Endpoint[Option[String], (UUID, ObservationUpdateSC), ErrorMsg, ObservationSC, Any] =
+    val updateOneObservation: Endpoint[Option[String], (UUID, ObservationUpdateSC), ErrorMsg, ObservationSC, Any] =
         secureEndpoint
             .put
             .in(base / path[UUID]("observationUuid"))
@@ -445,4 +440,3 @@ class ObservationEndpoints(controller: ObservationController, jdbcRepository: Jd
         updateOneObservationImpl,
         deleteOneObservationImpl
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpoints.scala
@@ -17,7 +17,17 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.ObservationController
-import org.mbari.annosaurus.domain.{ConceptCount, Count, CountForVideoReferenceSC, ErrorMsg, ObservationSC, ObservationUpdateSC, ObservationsUpdate, RenameConcept, RenameCountSC}
+import org.mbari.annosaurus.domain.{
+    ConceptCount,
+    Count,
+    CountForVideoReferenceSC,
+    ErrorMsg,
+    ObservationSC,
+    ObservationUpdateSC,
+    ObservationsUpdate,
+    RenameConcept,
+    RenameCountSC
+}
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
 import sttp.tapir.*
@@ -320,7 +330,11 @@ class ObservationEndpoints(controller: ObservationController, jdbcRepository: Jd
         secureEndpoint
             .put
             .in(base / "bulk")
-            .in(jsonBody[ObservationsUpdate].description("Describes the parameters and uuids of the observations to update. Can be camelCase or snake_case."))
+            .in(
+                jsonBody[ObservationsUpdate].description(
+                    "Describes the parameters and uuids of the observations to update. Can be camelCase or snake_case."
+                )
+            )
             .out(jsonBody[Count].description("The number of observations updated"))
             .name("updateManyObservations")
             .description(

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpoints.scala
@@ -28,15 +28,15 @@ import org.mbari.annosaurus.domain.{
     RenameConcept,
     RenameCountSC
 }
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
+import org.mbari.annosaurus.etc.circe.CirceCodecs.given
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
+import org.mbari.annosaurus.repository.jdbc.JdbcRepository
+import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import sttp.model.StatusCode
-import CustomTapirJsonCirce.*
-import org.mbari.annosaurus.repository.jdbc.JdbcRepository
 
 import java.time.Instant
 import java.util.UUID

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
@@ -16,18 +16,15 @@
 
 package org.mbari.annosaurus.endpoints
 
-import sttp.capabilities.Streams
 import org.mbari.annosaurus.controllers.QueryController
 import org.mbari.annosaurus.domain.{Count, ErrorMsg, QueryRequest}
 import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.repository.query.{JDBC, QueryResults}
-// import sttp.capabilities.fs2.Fs2Streams
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.ServerEndpoint.Full
-// import fs2.{Chunk, Stream}
 
 import scala.concurrent.{ExecutionContext, Future}
 import java.nio.charset.StandardCharsets

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
@@ -27,7 +27,6 @@ import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.ServerEndpoint.Full
 
 import scala.concurrent.{ExecutionContext, Future}
-import java.nio.charset.StandardCharsets
 
 class QueryEndpoints(queryController: QueryController)(using executionContext: ExecutionContext) extends Endpoints:
 
@@ -62,9 +61,9 @@ class QueryEndpoints(queryController: QueryController)(using executionContext: E
             )
         )
 
-    // val runQueryStreaming = 
+    // val runQueryStreaming =
     //     openEndpoint
-    //         .post 
+    //         .post
     //         .in(base / "run")
     //         .in(jsonBody[QueryRequest])
     //         .out(streamTextBody(Fs2Streams[Future]), (CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8)))

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
@@ -16,22 +16,17 @@
 
 package org.mbari.annosaurus.endpoints
 
-import CustomTapirJsonCirce.*
 import org.mbari.annosaurus.controllers.QueryController
 import org.mbari.annosaurus.domain.{Count, ErrorMsg, QueryRequest}
+import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
 import org.mbari.annosaurus.repository.query.{JDBC, QueryResults}
-import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.ServerEndpoint.Full
 
-import scala.util.Success
 import scala.concurrent.{ExecutionContext, Future}
-
-import org.mbari.annosaurus.etc.tapir.TapirCodecs
 
 class QueryEndpoints(queryController: QueryController)(using executionContext: ExecutionContext) extends Endpoints:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
@@ -16,17 +16,21 @@
 
 package org.mbari.annosaurus.endpoints
 
+import sttp.capabilities.Streams
 import org.mbari.annosaurus.controllers.QueryController
 import org.mbari.annosaurus.domain.{Count, ErrorMsg, QueryRequest}
 import org.mbari.annosaurus.endpoints.CustomTapirJsonCirce.*
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.repository.query.{JDBC, QueryResults}
+// import sttp.capabilities.fs2.Fs2Streams
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.ServerEndpoint.Full
+// import fs2.{Chunk, Stream}
 
 import scala.concurrent.{ExecutionContext, Future}
+import java.nio.charset.StandardCharsets
 
 class QueryEndpoints(queryController: QueryController)(using executionContext: ExecutionContext) extends Endpoints:
 
@@ -60,6 +64,23 @@ class QueryEndpoints(queryController: QueryController)(using executionContext: E
                 queryController.query(request).map(QueryResults.toTsv)
             )
         )
+
+    // val runQueryStreaming = 
+    //     openEndpoint
+    //         .post 
+    //         .in(base / "run")
+    //         .in(jsonBody[QueryRequest])
+    //         .out(streamTextBody(Fs2Streams[Future]), (CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8)))
+    //         .name("runQueryStreaming")
+    //         .description("Run a query and stream the results")
+    //         .tag(tag)
+
+    // val runQueryStreamingImpl: Full[Unit, Unit, QueryRequest, ErrorMsg, Future[Seq[String]], Any, Future] =
+    //     runQueryStreaming.serverLogic(request =>
+    //         handleEitherAsync(
+    //             queryController.query(request).map(QueryResults.toTsvStream)
+    //         )
+    //     )
 
     val count: Endpoint[Unit, QueryRequest, ErrorMsg, Count, Any] = openEndpoint
         .post

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
@@ -73,7 +73,7 @@ class QueryEndpoints(queryController: QueryController)(using executionContext: E
     val countImpl: Full[Unit, Unit, QueryRequest, ErrorMsg, Count, Any, Future] =
         count.serverLogic(request => handleEitherAsync(queryController.count(request)))
 
-    override def all: List[Endpoint[_, _, _, _, _]] = List(
+    override def all: List[Endpoint[?, ?, ?, ?, ?]] = List(
         listColumns,
         runQuery,
         count

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
@@ -31,6 +31,8 @@ import sttp.tapir.server.ServerEndpoint.Full
 import scala.util.Success
 import scala.concurrent.{ExecutionContext, Future}
 
+import org.mbari.annosaurus.etc.tapir.TapirCodecs
+
 class QueryEndpoints(queryController: QueryController)(using executionContext: ExecutionContext)
     extends Endpoints {
 
@@ -54,7 +56,6 @@ class QueryEndpoints(queryController: QueryController)(using executionContext: E
             .in(base / "run")
             .in(jsonBody[QueryRequest])
             .out(stringBody)
-            .out(header("Content-Type", "text/tab-separated-values"))
             .name("runQuery")
             .description("Run a query")
             .tag(tag)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.endpoints
+
+import CustomTapirJsonCirce.*
+import org.mbari.annosaurus.controllers.QueryController
+import org.mbari.annosaurus.domain.{ErrorMsg, QueryRequest}
+import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
+import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
+import org.mbari.annosaurus.repository.query.{JDBC, QueryResults}
+import sttp.model.StatusCode
+import sttp.tapir.*
+import sttp.tapir.generic.auto.*
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.ServerEndpoint.Full
+
+import scala.util.Success
+import scala.concurrent.{ExecutionContext, Future}
+
+class QueryEndpoints(queryController: QueryController)(using executionContext: ExecutionContext)
+    extends Endpoints {
+
+    private val base = "query"
+    private val tag  = "Query"
+
+    val listColumns: Endpoint[Unit, Unit, ErrorMsg, Seq[JDBC.Metadata], Any] = openEndpoint
+        .get
+        .in(base / "columns")
+        .out(jsonBody[Seq[JDBC.Metadata]])
+        .name("listQueryColumns")
+        .description("List columns in the query view")
+        .tag(tag)
+
+    val listColumnsImpl: Full[Unit, Unit, Unit, ErrorMsg, Seq[JDBC.Metadata], Any, Future] =
+        listColumns.serverLogic(_ => handleEitherAsync(queryController.listColumns()))
+
+    val runQuery: Endpoint[Unit, QueryRequest, ErrorMsg, String, Any] =
+        openEndpoint
+            .post
+            .in(base / "run")
+            .in(jsonBody[QueryRequest])
+            .out(stringBody)
+            .out(header("Content-Type", "text/tab-separated-values"))
+            .name("runQuery")
+            .description("Run a query")
+            .tag(tag)
+
+    val runQueryImpl =
+        runQuery.serverLogic(request =>
+            handleEitherAsync(
+                queryController.query(request).map(QueryResults.toTsv).map(_.mkString("\n"))
+            )
+        )
+
+    override def all: List[Endpoint[_, _, _, _, _]] = List(
+        listColumns,
+        runQuery
+    )
+
+    override def allImpl: List[ServerEndpoint[Any, Future]] = List(
+        listColumnsImpl,
+        runQueryImpl
+    )
+}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpoints.scala
@@ -33,8 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import org.mbari.annosaurus.etc.tapir.TapirCodecs
 
-class QueryEndpoints(queryController: QueryController)(using executionContext: ExecutionContext)
-    extends Endpoints {
+class QueryEndpoints(queryController: QueryController)(using executionContext: ExecutionContext) extends Endpoints:
 
     private val base = "query"
     private val tag  = "Query"
@@ -90,4 +89,3 @@ class QueryEndpoints(queryController: QueryController)(using executionContext: E
         runQueryImpl,
         countImpl
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/circe/CirceCodecs.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/circe/CirceCodecs.scala
@@ -21,13 +21,13 @@ import io.circe.generic.semiauto.*
 import io.circe.syntax.*
 import org.mbari.annosaurus.util.HexUtil
 import org.mbari.annosaurus.domain.*
-import org.mbari.annosaurus.repository.query.{Constraint, Query, JDBC}
+import org.mbari.annosaurus.repository.query.{Constraint, JDBC, Query}
 
 import java.net.{URI, URL}
 import java.time.Instant
 import scala.util.Try
 
-object CirceCodecs {
+object CirceCodecs:
     given Encoder[Array[Byte]] = (xs: Array[Byte]) => Json.fromString(HexUtil.toHex(xs))
     given Decoder[Array[Byte]] = Decoder
         .decodeString
@@ -332,12 +332,12 @@ object CirceCodecs {
         observationsUpdateCcDecoder or observationsUpdateScDecoder.map(_.toCamelCase)
 
     // Custom Decoder for Constraint
-    given constraintDecoder: Decoder[Constraint] = (c: HCursor) => {
-        for {
+    given constraintDecoder: Decoder[Constraint] = (c: HCursor) =>
+        for
             columnName <- c.downField("column").as[String]
             // Determine which constraint key is present
-            constraint <- {
-                if (c.downField("between").succeeded) {
+            constraint <-
+                if c.downField("between").succeeded then
                     // Attempt to decode between as List[Int] first
                     c.downField("between")
                         .as[List[Double]]
@@ -348,51 +348,37 @@ object CirceCodecs {
                                 .as[List[Instant]]
                                 .map(xs => Constraint.Date(columnName, xs.head, xs.last))
                         }
-                }
-                else if (c.downField("contains").succeeded) {
+                else if c.downField("contains").succeeded then
                     c.downField("contains").as[String].map(Constraint.Contains(columnName, _))
-                }
-                else if (c.downField("equals").succeeded) {
+                else if c.downField("equals").succeeded then
                     c.downField("equals").as[String].map(Constraint.Equals(columnName, _))
-                }
-                else if (c.downField("in").succeeded) {
+                else if c.downField("in").succeeded then
                     c.downField("in").as[List[String]].map(Constraint.In(columnName, _))
-                }
-                else if (c.downField("isnull").succeeded) {
+                else if c.downField("isnull").succeeded then
                     c.downField("isnull").as[Boolean].map(Constraint.IsNull(columnName, _))
-                }
-                else if (c.downField("like").succeeded) {
+                else if c.downField("like").succeeded then
                     c.downField("like").as[String].map(Constraint.Like(columnName, _))
-                }
-                else if (c.downField("max").succeeded) {
+                else if c.downField("max").succeeded then
                     c.downField("max").as[Double].map(Constraint.Max(columnName, _))
-                }
-                else if (c.downField("min").succeeded) {
+                else if c.downField("min").succeeded then
                     c.downField("min").as[Double].map(Constraint.Min(columnName, _))
-                }
-
-                else if (c.downField("minmax").succeeded) {
+                else if c.downField("minmax").succeeded then
                     c.downField("minmax")
                         .as[List[Double]]
                         .map(xs => Constraint.MinMax(columnName, xs.head, xs.last))
-                }
-                else {
-                    Left(DecodingFailure("Unknown constraint type", c.history))
-                }
-            }
-        } yield constraint
-    }
+                else Left(DecodingFailure("Unknown constraint type", c.history))
+        yield constraint
 
-    given Encoder[Constraint.Date]       = deriveEncoder
-    given Encoder[Constraint.Contains]   = deriveEncoder
-    given Encoder[Constraint.Equals[String]]     = deriveEncoder
-    given Encoder[Constraint.In[String]] = deriveEncoder
-    given Encoder[Constraint.IsNull]     = deriveEncoder
-    given Encoder[Constraint.Like]       = deriveEncoder
-    given Encoder[Constraint.Max]        = deriveEncoder
-    given Encoder[Constraint.MinMax]     = deriveEncoder
-    given Encoder[Constraint.Min]        = deriveEncoder
-    given Encoder[List[Constraint]]      = deriveEncoder
+    given Encoder[Constraint.Date]           = deriveEncoder
+    given Encoder[Constraint.Contains]       = deriveEncoder
+    given Encoder[Constraint.Equals[String]] = deriveEncoder
+    given Encoder[Constraint.In[String]]     = deriveEncoder
+    given Encoder[Constraint.IsNull]         = deriveEncoder
+    given Encoder[Constraint.Like]           = deriveEncoder
+    given Encoder[Constraint.Max]            = deriveEncoder
+    given Encoder[Constraint.MinMax]         = deriveEncoder
+    given Encoder[Constraint.Min]            = deriveEncoder
+    given Encoder[List[Constraint]]          = deriveEncoder
 
     // THis is needed to handle the trait Constraint used in Constraints
     given constraintEncoder: Encoder[Constraint] = Encoder.instance[Constraint] {
@@ -410,10 +396,10 @@ object CirceCodecs {
 
     given constraintRequestDecoder: Decoder[ConstraintRequest] = deriveDecoder
     given constraintRequestEncoder: Encoder[ConstraintRequest] = deriveEncoder
-    given queryRequestDecoder: Decoder[QueryRequest]  = deriveDecoder
-    given queryRequestEncoder: Encoder[QueryRequest]  = deriveEncoder
-    given jdbcMetadataDecoder: Decoder[JDBC.Metadata] = deriveDecoder
-    given jdbcMetadataEncoder: Encoder[JDBC.Metadata] = deriveEncoder
+    given queryRequestDecoder: Decoder[QueryRequest]           = deriveDecoder
+    given queryRequestEncoder: Encoder[QueryRequest]           = deriveEncoder
+    given jdbcMetadataDecoder: Decoder[JDBC.Metadata]          = deriveDecoder
+    given jdbcMetadataEncoder: Encoder[JDBC.Metadata]          = deriveEncoder
 
     val CustomPrinter: Printer = Printer(
         dropNullValues = true,
@@ -423,26 +409,27 @@ object CirceCodecs {
 //    @deprecated("Use stringify[T: Encoder] instead", "2021-11-23T11:00:00")
 //    def print[T: Encoder](t: T): String = CustomPrinter.print(t.asJson)
 
-    /** Convert a circe Json object to a JSON string
-      *
-      * @param value
-      *   Any value with an implicit circe coder in scope
-      */
+    /**
+     * Convert a circe Json object to a JSON string
+     *
+     * @param value
+     *   Any value with an implicit circe coder in scope
+     */
     extension (json: Json) def stringify: String = CustomPrinter.print(json)
 
-    /** Convert an object to a JSON string
-      *
-      * @param value
-      *   Any value with an implicit circe coder in scope
-      */
+    /**
+     * Convert an object to a JSON string
+     *
+     * @param value
+     *   Any value with an implicit circe coder in scope
+     */
     extension [T: Encoder](value: T)
         def stringify: String = Encoder[T]
             .apply(value)
             .deepDropNullValues
             .stringify
 
-    extension [T: Decoder](jsonString: String)
-        def toJson: Either[ParsingFailure, Json] = parser.parse(jsonString);
+    extension [T: Decoder](jsonString: String) def toJson: Either[ParsingFailure, Json] = parser.parse(jsonString);
 
     extension (jsonString: String)
         def reify[T: Decoder]: Either[Error, T] =
@@ -450,5 +437,3 @@ object CirceCodecs {
                 json   <- jsonString.toJson
                 result <- Decoder[T].apply(json.hcursor)
             yield result
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/circe/CirceCodecs.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/circe/CirceCodecs.scala
@@ -21,7 +21,7 @@ import io.circe.generic.semiauto.*
 import io.circe.syntax.*
 import org.mbari.annosaurus.util.HexUtil
 import org.mbari.annosaurus.domain.*
-import org.mbari.annosaurus.repository.query.Constraint
+import org.mbari.annosaurus.repository.query.{Constraint, Constraints}
 
 import java.net.{URI, URL}
 import java.time.Instant
@@ -360,6 +360,8 @@ object CirceCodecs {
             }
         } yield constraint
     }
+    
+    given constraintsDecoder: Decoder[Constraints] = deriveDecoder
 
 
     val CustomPrinter: Printer = Printer(

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/circe/CirceCodecs.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/circe/CirceCodecs.scala
@@ -19,9 +19,9 @@ package org.mbari.annosaurus.etc.circe
 import io.circe.*
 import io.circe.generic.semiauto.*
 import io.circe.syntax.*
-import org.mbari.annosaurus.util.HexUtil
 import org.mbari.annosaurus.domain.*
 import org.mbari.annosaurus.repository.query.{Constraint, JDBC, Query}
+import org.mbari.annosaurus.util.HexUtil
 
 import java.net.{URI, URL}
 import java.time.Instant

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/circe/CirceCodecs.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/circe/CirceCodecs.scala
@@ -21,7 +21,7 @@ import io.circe.generic.semiauto.*
 import io.circe.syntax.*
 import org.mbari.annosaurus.util.HexUtil
 import org.mbari.annosaurus.domain.*
-import org.mbari.annosaurus.repository.query.{Constraint, Constraints, JDBC}
+import org.mbari.annosaurus.repository.query.{Constraint, Query, JDBC}
 
 import java.net.{URI, URL}
 import java.time.Instant
@@ -396,9 +396,11 @@ object CirceCodecs {
         case c: Constraint.Date       => c.asJson
     }
 
-    given constraintsDecoder: Decoder[Constraints] = deriveDecoder
-    given constraintsEncoder: Encoder[Constraints] = deriveEncoder
+    given constraintsDecoder: Decoder[Query] = deriveDecoder
+    given constraintsEncoder: Encoder[Query] = deriveEncoder
 
+    given constraintRequestDecoder: Decoder[ConstraintRequest] = deriveDecoder
+    given constraintRequestEncoder: Encoder[ConstraintRequest] = deriveEncoder
     given queryRequestDecoder: Decoder[QueryRequest]  = deriveDecoder
     given queryRequestEncoder: Encoder[QueryRequest]  = deriveEncoder
     given jdbcMetadataDecoder: Decoder[JDBC.Metadata] = deriveDecoder

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jdk/Instants.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jdk/Instants.scala
@@ -16,8 +16,8 @@
 
 package org.mbari.annosaurus.etc.jdk
 
-import java.time.{Instant, ZoneId}
 import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId}
 import scala.util.Try
 
 object Instants:

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jdk/Loggers.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jdk/Loggers.scala
@@ -33,7 +33,7 @@ import java.util.function.Supplier
  * }}}
  * * @author Brian Schlining
  */
-object Logging:
+object Loggers:
 
     trait Builder:
         def logger: Logger

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jdk/Logging.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jdk/Logging.scala
@@ -20,18 +20,19 @@ import java.lang.System.Logger
 import java.lang.System.Logger.Level
 import java.util.function.Supplier
 
-/** Add fluent logging to System.Logger. Usage:
-  * {{{
-  * import org.fathomnet.support.etc.jdk.Logging.{given, *}
-  * given log: Logger = Sytem.getLogger("my.logger")
-  *
-  * log.atInfo.log("Hello World")
-  * log.atInfo.withCause(new RuntimeException("Oops")).log("Hello World")
-  *
-  * 3.tapLog.atInfo.log(i => s"Hello World $i")
-  * }}}
-  * * @author Brian Schlining
-  */
+/**
+ * Add fluent logging to System.Logger. Usage:
+ * {{{
+ * import org.fathomnet.support.etc.jdk.Logging.{given, *}
+ * given log: Logger = Sytem.getLogger("my.logger")
+ *
+ * log.atInfo.log("Hello World")
+ * log.atInfo.withCause(new RuntimeException("Oops")).log("Hello World")
+ *
+ * 3.tapLog.atInfo.log(i => s"Hello World $i")
+ * }}}
+ * * @author Brian Schlining
+ */
 object Logging:
 
     trait Builder:

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jdk/Numbers.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jdk/Numbers.scala
@@ -18,7 +18,7 @@ package org.mbari.annosaurus.etc.jdk
 
 import scala.util.Try
 
-object Numbers {
+object Numbers:
 
     extension (obj: Object | Number)
         def asDouble: Option[Double] = Numbers.doubleConverter(obj)
@@ -57,5 +57,3 @@ object Numbers {
             case n: Number => Some(n.intValue())
             case s: String => Try(s.toInt).toOption
             case _         => None
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jdk/Uris.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jdk/Uris.scala
@@ -16,10 +16,9 @@
 
 package org.mbari.annosaurus.etc.jdk
 
-import java.net.URI
-import java.nio.file.Paths
-import java.net.URLEncoder
+import java.net.{URI, URLEncoder}
 import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
 
 object Uris:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jpa/EntityManagers.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jpa/EntityManagers.scala
@@ -17,7 +17,7 @@
 package org.mbari.annosaurus.etc.jpa
 
 import jakarta.persistence.EntityManager
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 
 import scala.util.control.NonFatal
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jpa/EntityManagers.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jpa/EntityManagers.scala
@@ -17,11 +17,9 @@
 package org.mbari.annosaurus.etc.jpa
 
 import jakarta.persistence.EntityManager
-import org.checkerframework.checker.units.qual.N
+import org.mbari.annosaurus.etc.jdk.Logging.given
 
 import scala.util.control.NonFatal
-import org.mbari.annosaurus.etc.jdk.Logging.given
-import org.hibernate.Session
 
 object EntityManagers:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jpa/EntityManagers.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jpa/EntityManagers.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.etc.jpa
+
+import jakarta.persistence.EntityManager
+import org.checkerframework.checker.units.qual.N
+
+import scala.util.control.NonFatal
+import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.hibernate.Session
+
+object EntityManagers:
+
+    private val log = System.getLogger(getClass.getName)
+
+    extension (entityManager: EntityManager)
+        def runTransaction[R](fn: EntityManager => R): Either[Throwable, R] =
+
+            val transaction = entityManager.getTransaction
+            transaction.begin()
+            try
+                val n = fn.apply(entityManager)
+                transaction.commit()
+                Right(n)
+            catch
+                case NonFatal(e) =>
+                    log.atError.withCause(e).log("Error in transaction: " + e.getCause)
+                    Left(e)
+            finally if transaction.isActive then transaction.rollback()
+
+        // def runQuery[R](fn: EntityManager => R): Either[Throwable, R] =
+        //     entityManager.unwrap(classOf[Session]).setDefaultReadOnly(true)
+        //     val transaction = entityManager.getTransaction
+
+        //     try
+        //         transaction.begin()
+        //         val n = fn.apply(entityManager)
+        //         // transaction.commit()
+        //         Right(n)
+        //     catch
+        //         case NonFatal(e) =>
+        //             log.atError.withCause(e).log("Error in transaction: " + e.getCause)
+        //             Left(e)
+        //     finally
+        //         if transaction.isActive then
+        //             transaction.rollback()

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jwt/BasicJwtService.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jwt/BasicJwtService.scala
@@ -16,15 +16,15 @@
 
 package org.mbari.vampiresquid.etc.jwt
 
-import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.JWT
-import com.typesafe.config.ConfigFactory
+import com.auth0.jwt.algorithms.Algorithm
+import org.mbari.annosaurus.JwtParams
+import org.mbari.annosaurus.domain.Authorization
+
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Date
 import scala.util.control.NonFatal
-import org.mbari.annosaurus.JwtParams
-import org.mbari.annosaurus.domain.Authorization
 
 /**
  * To use this authentication. The client and server should both have a shared secret (aka client secret). The client

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jwt/JwtService.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jwt/JwtService.scala
@@ -22,7 +22,7 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Date
 
-case class JwtService(issuer: String, apiKey: String, signingSecret: String) {
+case class JwtService(issuer: String, apiKey: String, signingSecret: String):
 
     private val algorithm = Algorithm.HMAC512(signingSecret)
 
@@ -32,16 +32,13 @@ case class JwtService(issuer: String, apiKey: String, signingSecret: String) {
         .build()
 
     def verify(jwt: String): Boolean =
-        try {
+        try
             verifier.verify(jwt)
             true
-        }
-        catch {
-            case e: Exception => false
-        }
+        catch case e: Exception => false
 
     def authorize(providedApiKey: String): Option[String] =
-        if (providedApiKey == apiKey) {
+        if providedApiKey == apiKey then
             val now      = Instant.now()
             val tomorrow = now.plus(1, ChronoUnit.DAYS)
             val iat      = Date.from(now)
@@ -54,6 +51,4 @@ case class JwtService(issuer: String, apiKey: String, signingSecret: String) {
                 .withExpiresAt(exp)
                 .sign(algorithm)
             Some(jwt)
-        }
         else None
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jwt/JwtService.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/jwt/JwtService.scala
@@ -16,8 +16,9 @@
 
 package org.mbari.annosaurus.etc.jwt
 
-import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Date

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/sdk/Futures.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/sdk/Futures.scala
@@ -25,11 +25,12 @@ object Futures:
 
     private val Timeout = Duration.apply(10, TimeUnit.SECONDS)
 
-    /** Join a future. (i.e. Await.result(future, Duration.Inf)
-      *
-      * @return
-      *   The result of the future
-      */
+    /**
+     * Join a future. (i.e. Await.result(future, Duration.Inf)
+     *
+     * @return
+     *   The result of the future
+     */
     extension [T](t: Future[T])
         def join: T                      = Await.result(t, Timeout)
         def join(duration: Duration): T  = Await.result(t, duration)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/sdk/Futures.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/sdk/Futures.scala
@@ -16,10 +16,10 @@
 
 package org.mbari.annosaurus.etc.sdk
 
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration.Duration
-import java.util.concurrent.TimeUnit
 import java.time.Duration as JDuration
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 
 object Futures:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/sdk/Reflect.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/sdk/Reflect.scala
@@ -16,8 +16,8 @@
 
 package org.mbari.annosaurus.etc.sdk
 
-import scala.reflect.ClassTag
 import scala.jdk.CollectionConverters.*
+import scala.reflect.ClassTag
 
 object Reflect:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/sdk/Reflect.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/sdk/Reflect.scala
@@ -21,18 +21,19 @@ import scala.jdk.CollectionConverters.*
 
 object Reflect:
 
-    /** Create an instance of a class from a Map of parameters. The keys of the map must match the
-      * names of the constructor parameters. This works for both case classes and regular classes.
-      *
-      * @param m
-      *   The map of parameters
-      * @tparam T
-      *   The type of the class to create
-      * @return
-      *   A new instance of the class
-      * @throws IllegalArgumentException
-      *   if a required parameter is missing
-      */
+    /**
+     * Create an instance of a class from a Map of parameters. The keys of the map must match the names of the
+     * constructor parameters. This works for both case classes and regular classes.
+     *
+     * @param m
+     *   The map of parameters
+     * @tparam T
+     *   The type of the class to create
+     * @return
+     *   A new instance of the class
+     * @throws IllegalArgumentException
+     *   if a required parameter is missing
+     */
     def fromMap[T: ClassTag](m: Map[String, ?]): T =
         val classTag        = implicitly[ClassTag[T]]
         val constructor     = classTag.runtimeClass.getDeclaredConstructors.head
@@ -51,32 +52,32 @@ object Reflect:
             }
         constructor.newInstance(constructorArgs*).asInstanceOf[T]
 
-    /** Create an instance of a class from a java.util.Map of parameters. The keys of the map must
-      * match the names of the constructor parameters. This works for both case classes and regular
-      * classes.
-      *
-      * @param m
-      *   The map of parameters
-      * @tparam T
-      *   The type of the class to create
-      * @return
-      *   A new instance of the class
-      * @throws IllegalArgumentException
-      *   if a required parameter is missing
-      */
+    /**
+     * Create an instance of a class from a java.util.Map of parameters. The keys of the map must match the names of the
+     * constructor parameters. This works for both case classes and regular classes.
+     *
+     * @param m
+     *   The map of parameters
+     * @tparam T
+     *   The type of the class to create
+     * @return
+     *   A new instance of the class
+     * @throws IllegalArgumentException
+     *   if a required parameter is missing
+     */
     def fromJavaMap[T: ClassTag](m: java.util.Map[String, ?]): T =
         fromMap(m.asScala.toMap)
 
-    /** Convert a case class to a Map of parameters. The keys of the map are the names of the
-      * constructor parameters.
-      *
-      * @param t
-      *   The case class to convert
-      * @tparam T
-      *   The type of the case class
-      * @return
-      *   A Map of parameters
-      */
+    /**
+     * Convert a case class to a Map of parameters. The keys of the map are the names of the constructor parameters.
+     *
+     * @param t
+     *   The case class to convert
+     * @tparam T
+     *   The type of the case class
+     * @return
+     *   A Map of parameters
+     */
     def toMap[T: ClassTag](t: T): Map[String, ?] =
         val classTag = implicitly[ClassTag[T]]
         val fields   = classTag.runtimeClass.getDeclaredFields
@@ -88,18 +89,16 @@ object Reflect:
     def toFormBody[T: ClassTag](t: T): String =
         toMap(t)
             .filter { case (_, v) => // Remove nulls and None
-                v match {
+                v match
                     case null => false
                     case None => false
                     case _    => true
-                }
             }
             .map { // Convert Some(x) to x
                 case (k, v) =>
-                    val d = v match {
+                    val d = v match
                         case Some(x) => x
                         case x       => x
-                    }
                     k -> d
             }
             .map { case (k, v) => s"$k=$v" }

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/tapir/TapirCodecs.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/tapir/TapirCodecs.scala
@@ -24,7 +24,6 @@ import java.net.{URI, URL}
 import java.time.Instant
 import java.util.HexFormat
 import scala.util.{Failure, Success, Try}
-import org.mbari.annosaurus.repository.query.QueryResults
 
 object TapirCodecs:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/tapir/TapirCodecs.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/tapir/TapirCodecs.scala
@@ -18,12 +18,13 @@ package org.mbari.annosaurus.etc.tapir
 
 import org.mbari.annosaurus.etc.jdk.Instants
 import sttp.tapir.CodecFormat.TextPlain
-import sttp.tapir.{Codec, DecodeResult}
+import sttp.tapir.{Codec, CodecFormat, DecodeResult}
 
 import java.net.{URI, URL}
 import java.time.Instant
 import java.util.HexFormat
 import scala.util.{Failure, Success, Try}
+import org.mbari.annosaurus.repository.query.QueryResults
 
 object TapirCodecs:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/zeromq/ZeroMQPublisher.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/zeromq/ZeroMQPublisher.scala
@@ -19,10 +19,10 @@ package org.mbari.annosaurus.etc.zeromq
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import io.reactivex.rxjava3.subjects.Subject
-import org.mbari.annosaurus.messaging.{GenericMessage, MessageBus}
 import org.mbari.annosaurus.ZeroMQConfig
 import org.mbari.annosaurus.etc.jdk.Logging
 import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+import org.mbari.annosaurus.messaging.{GenericMessage, MessageBus}
 import org.zeromq.{SocketType, ZContext}
 
 import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/etc/zeromq/ZeroMQPublisher.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/etc/zeromq/ZeroMQPublisher.scala
@@ -20,8 +20,8 @@ import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import io.reactivex.rxjava3.subjects.Subject
 import org.mbari.annosaurus.ZeroMQConfig
-import org.mbari.annosaurus.etc.jdk.Logging
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+import org.mbari.annosaurus.etc.jdk.Loggers
+import org.mbari.annosaurus.etc.jdk.Loggers.{*, given}
 import org.mbari.annosaurus.messaging.{GenericMessage, MessageBus}
 import org.zeromq.{SocketType, ZContext}
 
@@ -43,7 +43,7 @@ class ZeroMQPublisher(val topic: String, val port: Int, val subject: Subject[?])
         .observeOn(Schedulers.io())
         .distinct()
         .subscribe(m => queue.offer(m))
-    private val log                    = Logging(getClass)
+    private val log                    = Loggers(getClass)
 
     @volatile
     var ok     = true
@@ -77,7 +77,7 @@ class ZeroMQPublisher(val topic: String, val port: Int, val subject: Subject[?])
 
 object ZeroMQPublisher:
 
-    private val log = Logging(getClass)
+    private val log = Loggers(getClass)
 
     /**
      * @param opt

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/GenericMessage.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/GenericMessage.scala
@@ -20,36 +20,35 @@ import org.mbari.annosaurus.domain.Annotation
 import org.mbari.annosaurus.domain.Association
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 
-/** @author
-  *   Brian Schlining
-  * @since 2020-03-04T13:31:00
-  */
-sealed trait GenericMessage[+A] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2020-03-04T13:31:00
+ */
+sealed trait GenericMessage[+A]:
     def content: A
     def toJson: String
-}
 
-/** Send when a new annotation is created or an existing one is updated
-  * @param content
-  */
-case class AnnotationMessage(content: Annotation) extends GenericMessage[Annotation] {
+/**
+ * Send when a new annotation is created or an existing one is updated
+ * @param content
+ */
+case class AnnotationMessage(content: Annotation) extends GenericMessage[Annotation]:
 
     override def hashCode(): Int =
         this.content.observationUuid.hashCode() +
             this.content.observationTimestamp.hashCode() * 3
 
     override def equals(obj: Any): Boolean =
-        obj match {
+        obj match
             case that: AnnotationMessage =>
                 this.content.observationUuid == that.content.observationUuid &&
                 this.content.observationTimestamp == that.content.observationTimestamp
             case _                       => false
-        }
 
     override def toJson: String = content.stringify
-}
 
-case class AssociationMessage(content: Association) extends GenericMessage[Association] {
+case class AssociationMessage(content: Association) extends GenericMessage[Association]:
 //  override def hashCode(): Int = this.content.uuid.hashCode()
 //
 //  override def equals(obj: Any): Boolean = obj match {
@@ -57,7 +56,5 @@ case class AssociationMessage(content: Association) extends GenericMessage[Assoc
 //    case _ => false
 //  }
 
-    override def toJson: String = {
+    override def toJson: String =
         content.stringify
-    }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/GenericMessage.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/GenericMessage.scala
@@ -16,8 +16,7 @@
 
 package org.mbari.annosaurus.messaging
 
-import org.mbari.annosaurus.domain.Annotation
-import org.mbari.annosaurus.domain.Association
+import org.mbari.annosaurus.domain.{Annotation, Association}
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 
 /**

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/GenericPublisher.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/GenericPublisher.scala
@@ -17,11 +17,9 @@
 package org.mbari.annosaurus.messaging
 
 import io.reactivex.rxjava3.subjects.Subject
+import org.mbari.annosaurus.domain.{Annotation, Association, Observation}
 
 import scala.util.Try
-import org.mbari.annosaurus.domain.Annotation
-import org.mbari.annosaurus.domain.Observation
-import org.mbari.annosaurus.domain.Association
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/GenericPublisher.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/GenericPublisher.scala
@@ -23,34 +23,31 @@ import org.mbari.annosaurus.domain.Annotation
 import org.mbari.annosaurus.domain.Observation
 import org.mbari.annosaurus.domain.Association
 
-/** @author
-  *   Brian Schlining
-  * @since 2020-03-04T13:32:00
-  */
-trait GenericPublisher[A] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2020-03-04T13:32:00
+ */
+trait GenericPublisher[A]:
     def publish(x: A): Unit
     def publish(xs: Iterable[A]): Unit =
-        for {
-            x <- xs
-        } publish(x)
-    def publish(opt: Option[A]): Unit  = opt match {
+        for x <- xs
+        do publish(x)
+    def publish(opt: Option[A]): Unit  = opt match
         case None    => // do nothing
         case Some(a) => Try(publish(a))
-    }
-}
 
-/** Decorator for an reactive Subject that publishes AnnotationMessages for common use cases.
-  * @param subject
-  */
-class AnnotationPublisher(subject: Subject[Any]) extends GenericPublisher[Annotation] {
+/**
+ * Decorator for an reactive Subject that publishes AnnotationMessages for common use cases.
+ * @param subject
+ */
+class AnnotationPublisher(subject: Subject[Any]) extends GenericPublisher[Annotation]:
     def publish(annotation: Annotation): Unit   = Try(
         subject.onNext(AnnotationMessage(annotation))
     )
     def publish(observation: Observation): Unit = publish(Annotation.from(observation.toEntity))
-}
 
-class AssociationPublisher(subject: Subject[Any]) extends GenericPublisher[Association] {
+class AssociationPublisher(subject: Subject[Any]) extends GenericPublisher[Association]:
     def publish(association: Association): Unit = Try(
         subject.onNext(AssociationMessage(association))
     )
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/MessageBus.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/MessageBus.scala
@@ -20,20 +20,17 @@ import io.reactivex.rxjava3.subjects.{PublishSubject, Subject}
 
 import java.lang.System.Logger.Level
 
-/** This is the shared message bus. All publishers whould listen to this bus and publish the
-  * appropriate events to their subscribers.
-  *
-  * MessageBus.RxSubject: Subject[Any] ^ \| AnnotationPublisher.publish(msg)
-  */
-object MessageBus {
+/**
+ * This is the shared message bus. All publishers whould listen to this bus and publish the appropriate events to their
+ * subscribers.
+ *
+ * MessageBus.RxSubject: Subject[Any] ^ \| AnnotationPublisher.publish(msg)
+ */
+object MessageBus:
 
     private lazy val log = System.getLogger(getClass.getName)
 
     val RxSubject: Subject[Any] =
         PublishSubject.create[Any]().toSerialized
 
-    if (log.isLoggable(Level.TRACE)) {
-        RxSubject.subscribe(m => log.log(Level.TRACE, m.toString))
-    }
-
-}
+    if log.isLoggable(Level.TRACE) then RxSubject.subscribe(m => log.log(Level.TRACE, m.toString))

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/Using.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/messaging/Using.scala
@@ -18,35 +18,28 @@ package org.mbari.annosaurus.messaging
 
 import scala.util.control.NonFatal
 
-/** @author
-  *   Brian Schlining
-  * @since 2020-01-30T15:57:00
-  */
-object Using {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2020-01-30T15:57:00
+ */
+object Using:
 
-    def apply[T <: AutoCloseable, V](r: => T)(f: T => V): V = {
+    def apply[T <: AutoCloseable, V](r: => T)(f: T => V): V =
         val resource: T          = r
         require(resource != null, "resource is null")
         var exception: Throwable = null
-        try {
-            f(resource)
-        }
-        catch {
+        try f(resource)
+        catch
             case e: Throwable =>
                 exception = e
                 throw e
-        }
-        finally {
-            closeAndAddSuppressed(exception, resource)
-        }
-    }
+        finally closeAndAddSuppressed(exception, resource)
 
-    private def closeAndAddSuppressed(e: Throwable, resource: AutoCloseable): Unit = {
-        if (e != null) {
-            try {
-                resource.close()
-            }
-            catch {
+    private def closeAndAddSuppressed(e: Throwable, resource: AutoCloseable): Unit =
+        if e != null then
+            try resource.close()
+            catch
                 case NonFatal(suppressed)            =>
                     e.addSuppressed(suppressed)
                 case fatal: Throwable if NonFatal(e) =>
@@ -57,11 +50,4 @@ object Using {
                     throw fatal
                 case fatal: Throwable                =>
                     e.addSuppressed(fatal)
-            }
-        }
-        else {
-            resource.close()
-        }
-    }
-
-}
+        else resource.close()

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/AssociationDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/AssociationDAO.scala
@@ -17,10 +17,9 @@
 package org.mbari.annosaurus.repository
 
 import org.mbari.annosaurus.domain.{ConceptAssociation, ConceptAssociationRequest}
+import org.mbari.annosaurus.repository.jpa.entity.{AssociationEntity, IPersistentObject}
 
 import java.util.UUID
-import org.mbari.annosaurus.repository.jpa.entity.AssociationEntity
-import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/AssociationDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/AssociationDAO.scala
@@ -22,11 +22,12 @@ import java.util.UUID
 import org.mbari.annosaurus.repository.jpa.entity.AssociationEntity
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T16:08:00
-  */
-trait AssociationDAO[T <: IPersistentObject] extends DAO[T] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T16:08:00
+ */
+trait AssociationDAO[T <: IPersistentObject] extends DAO[T]:
 
     def newPersistentObject(
         linkName: String,
@@ -54,5 +55,3 @@ trait AssociationDAO[T <: IPersistentObject] extends DAO[T] {
     def countByToConcept(toConcept: String): Long
 
     def updateToConcept(oldToConcept: String, newToConcept: String): Int
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/CachedAncillaryDatumDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/CachedAncillaryDatumDAO.scala
@@ -16,8 +16,9 @@
 
 package org.mbari.annosaurus.repository
 
-import java.util.UUID
 import org.mbari.annosaurus.repository.jpa.entity.{AncillaryDatumDTO, IPersistentObject}
+
+import java.util.UUID
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/CachedAncillaryDatumDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/CachedAncillaryDatumDAO.scala
@@ -19,11 +19,12 @@ package org.mbari.annosaurus.repository
 import java.util.UUID
 import org.mbari.annosaurus.repository.jpa.entity.{AncillaryDatumDTO, IPersistentObject}
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T16:08:00
-  */
-trait CachedAncillaryDatumDAO[T <: IPersistentObject] extends DAO[T] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T16:08:00
+ */
+trait CachedAncillaryDatumDAO[T <: IPersistentObject] extends DAO[T]:
 
     def newPersistentObject(
         latitude: Double,
@@ -53,12 +54,11 @@ trait CachedAncillaryDatumDAO[T <: IPersistentObject] extends DAO[T] {
 
     def newPersistentObject(bean: T): T
 
-    /** Delete all ancillary data associated with annotations for a given video reference
-      * @param videoReferenceUuid
-      *   the VideoReference UUID
-      * @return
-      *   The number of rows deleted
-      */
+    /**
+     * Delete all ancillary data associated with annotations for a given video reference
+     * @param videoReferenceUuid
+     *   the VideoReference UUID
+     * @return
+     *   The number of rows deleted
+     */
     def deleteByVideoReferenceUuid(videoReferenceUuid: UUID): Int
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/CachedVideoReferenceInfoDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/CachedVideoReferenceInfoDAO.scala
@@ -16,9 +16,9 @@
 
 package org.mbari.annosaurus.repository
 
-import java.util.UUID
-
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
+
+import java.util.UUID
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/CachedVideoReferenceInfoDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/CachedVideoReferenceInfoDAO.scala
@@ -20,11 +20,12 @@ import java.util.UUID
 
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T16:10:00
-  */
-trait CachedVideoReferenceInfoDAO[T <: IPersistentObject] extends DAO[T] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T16:10:00
+ */
+trait CachedVideoReferenceInfoDAO[T <: IPersistentObject] extends DAO[T]:
 
     def findByVideoReferenceUUID(uuid: UUID): Option[T]
     def findByPlatformName(platformName: String): Iterable[T]
@@ -34,5 +35,3 @@ trait CachedVideoReferenceInfoDAO[T <: IPersistentObject] extends DAO[T] {
     def findAllMissionContacts(): Iterable[String]
     def findAllPlatformNames(): Iterable[String]
     def findAllMissionIDs(): Iterable[String]
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/DAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/DAO.scala
@@ -16,7 +16,6 @@
 
 package org.mbari.annosaurus.repository
 
-import jakarta.persistence.Entity
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 
 import java.util.UUID

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/DAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/DAO.scala
@@ -22,15 +22,16 @@ import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
-/** All DAOs should implement this trait as it defines the minimum CRUD methods needed.
-  *
-  * @author
-  *   Brian Schlining
-  * @since 2016-05-05T12:44:00
-  * @tparam A
-  *   The type of the entity
-  */
-trait DAO[A <: IPersistentObject] extends AutoCloseable {
+/**
+ * All DAOs should implement this trait as it defines the minimum CRUD methods needed.
+ *
+ * @author
+ *   Brian Schlining
+ * @since 2016-05-05T12:44:00
+ * @tparam A
+ *   The type of the entity
+ */
+trait DAO[A <: IPersistentObject] extends AutoCloseable:
 
     def newPersistentObject(): A
     def create(entity: A): Unit
@@ -44,5 +45,3 @@ trait DAO[A <: IPersistentObject] extends AutoCloseable {
     def flush(): Unit
     def commit(): Unit
     def isDetached(entity: A): Boolean
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ImageReferenceDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ImageReferenceDAO.scala
@@ -21,11 +21,12 @@ import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 
 import java.net.URL
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T16:10:00
-  */
-trait ImageReferenceDAO[T <: IPersistentObject] extends DAO[T] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T16:10:00
+ */
+trait ImageReferenceDAO[T <: IPersistentObject] extends DAO[T]:
 
     def newPersistentObject(
         url: URL,
@@ -38,5 +39,3 @@ trait ImageReferenceDAO[T <: IPersistentObject] extends DAO[T] {
     def findByURL(url: URL): Option[T]
 
     def findByImageName(name: String): Seq[ImageReferenceEntity]
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ImageReferenceDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ImageReferenceDAO.scala
@@ -16,8 +16,7 @@
 
 package org.mbari.annosaurus.repository
 
-import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
-import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
+import org.mbari.annosaurus.repository.jpa.entity.{IPersistentObject, ImageReferenceEntity}
 
 import java.net.URL
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ImagedMomentDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ImagedMomentDAO.scala
@@ -165,7 +165,7 @@ trait ImagedMomentDAO[T <: IPersistentObject] extends DAO[T]:
                 val im0 = elapsedTime.flatMap(findByVideoReferenceUUIDAndElapsedTime(uuid, _))
                 if im0.isEmpty then recordedDate.flatMap(findByVideoReferenceUUIDAndRecordedDate(uuid, _))
                 else im0
-        // This code has bug when resolving timecodes. See M3-15
+            // This code has bug when resolving timecodes. See M3-15
 //    val im0 = timecode.flatMap(findByVideoReferenceUUIDAndTimecode(uuid, _))
 //    val im1 = if (im0.isEmpty) elapsedTime.flatMap(findByVideoReferenceUUIDAndElapsedTime(uuid, _)) else im0
 //    if (im1.isEmpty) recordedDate.flatMap(findByVideoReferenceUUIDAndRecordedDate(uuid, _)) else im1

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ImagedMomentDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ImagedMomentDAO.scala
@@ -26,11 +26,12 @@ import org.mbari.vcr4j.time.Timecode
 import java.time.{Duration, Instant}
 import java.util.UUID
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T16:07:00
-  */
-trait ImagedMomentDAO[T <: IPersistentObject] extends DAO[T] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T16:07:00
+ */
+trait ImagedMomentDAO[T <: IPersistentObject] extends DAO[T]:
 
     def newPersistentObject(
         videoReferenceUUID: UUID,
@@ -41,19 +42,19 @@ trait ImagedMomentDAO[T <: IPersistentObject] extends DAO[T] {
 
     def newPersistentObject(imagedMoment: T): T
 
-    /** Find ImagedMoments where the imagedmoment OR observation has been updated between the
-      * requested dates.
-      * @param start
-      *   The starting date
-      * @param end
-      *   The ending date
-      * @param limit
-      *   The number of results to return. Default is all of them
-      * @param offset
-      *   The starting index of the results to return. Default is 0.
-      * @return
-      *   ImagedMoments between the given dates
-      */
+    /**
+     * Find ImagedMoments where the imagedmoment OR observation has been updated between the requested dates.
+     * @param start
+     *   The starting date
+     * @param end
+     *   The ending date
+     * @param limit
+     *   The number of results to return. Default is all of them
+     * @param offset
+     *   The starting index of the results to return. Default is 0.
+     * @return
+     *   ImagedMoments between the given dates
+     */
     def findBetweenUpdatedDates(
         start: Instant,
         end: Instant,
@@ -137,43 +138,39 @@ trait ImagedMomentDAO[T <: IPersistentObject] extends DAO[T] {
         offset: Option[Int] = None
     ): Iterable[T]
 
-    /** Look up an imaged moment based on the videoReferenceUUID and one of the indices into a
-      * video. The order of search is
-      *   1. Timecode 2. ElapsedTime 3. RecordedDate
-      *
-      * @param uuid
-      *   The videoReferenceUUID that the imagedMoment is attached to
-      * @param timecode
-      *   The timecode index
-      * @param elapsedTime
-      *   The elapsedTime index (This is the index of runtime into the video)
-      * @param recordedDate
-      *   The recordedDate index
-      * @return
-      *   None if no match is found. Some if a match exists
-      */
+    /**
+     * Look up an imaged moment based on the videoReferenceUUID and one of the indices into a video. The order of search
+     * is
+     *   1. Timecode 2. ElapsedTime 3. RecordedDate
+     *
+     * @param uuid
+     *   The videoReferenceUUID that the imagedMoment is attached to
+     * @param timecode
+     *   The timecode index
+     * @param elapsedTime
+     *   The elapsedTime index (This is the index of runtime into the video)
+     * @param recordedDate
+     *   The recordedDate index
+     * @return
+     *   None if no match is found. Some if a match exists
+     */
     def findByVideoReferenceUUIDAndIndex(
         uuid: UUID,
         timecode: Option[Timecode] = None,
         elapsedTime: Option[Duration] = None,
         recordedDate: Option[Instant] = None
-    ): Option[T] = {
-
+    ): Option[T] =
         // If timecode is supplied and no existing match is found return None.
-        timecode match {
+        timecode match
             case Some(t) => findByVideoReferenceUUIDAndTimecode(uuid, t)
             case None    =>
                 val im0 = elapsedTime.flatMap(findByVideoReferenceUUIDAndElapsedTime(uuid, _))
-                if (im0.isEmpty)
-                    recordedDate.flatMap(findByVideoReferenceUUIDAndRecordedDate(uuid, _))
+                if im0.isEmpty then recordedDate.flatMap(findByVideoReferenceUUIDAndRecordedDate(uuid, _))
                 else im0
-        }
         // This code has bug when resolving timecodes. See M3-15
 //    val im0 = timecode.flatMap(findByVideoReferenceUUIDAndTimecode(uuid, _))
 //    val im1 = if (im0.isEmpty) elapsedTime.flatMap(findByVideoReferenceUUIDAndElapsedTime(uuid, _)) else im0
 //    if (im1.isEmpty) recordedDate.flatMap(findByVideoReferenceUUIDAndRecordedDate(uuid, _)) else im1
-
-    }
 
     def findByObservationUUID(uuid: UUID): Option[T]
 
@@ -182,30 +179,30 @@ trait ImagedMomentDAO[T <: IPersistentObject] extends DAO[T] {
         recordedTimestamp: Instant
     ): Boolean
 
-    /** A bulk delete operation. This will delete all annotation related data for a single video.
-      * (which is identified via its uuid (e.g. videoReferenceUUID))
-      *
-      * @param uuid
-      *   The UUID of the VideoReference. WARNING!! All annotation data associated to this
-      *   videoReference will be deleted.
-      * @return
-      *   The number of records deleted
-      */
+    /**
+     * A bulk delete operation. This will delete all annotation related data for a single video. (which is identified
+     * via its uuid (e.g. videoReferenceUUID))
+     *
+     * @param uuid
+     *   The UUID of the VideoReference. WARNING!! All annotation data associated to this videoReference will be
+     *   deleted.
+     * @return
+     *   The number of records deleted
+     */
     def deleteByVideoReferenceUUUID(uuid: UUID): Int
 
-    /** Deletes an imagedMoment if it does not contain any observations or imageReferences
-      * @param imagedMoment
-      *   The object to delete
-      * @return
-      *   true if deleted, false if not deleted.
-      */
+    /**
+     * Deletes an imagedMoment if it does not contain any observations or imageReferences
+     * @param imagedMoment
+     *   The object to delete
+     * @return
+     *   true if deleted, false if not deleted.
+     */
     def deleteIfEmpty(imagedMoment: T): Boolean =
-        imagedMoment.primaryKey match {
+        imagedMoment.primaryKey match
             case Some(pk) => deleteIfEmptyByUUID(pk)
             case None     => false
-        }
 
     def deleteIfEmptyByUUID(uuid: UUID): Boolean
 
     def moveToVideoReference(newVideoReferenceUuid: UUID, imagedMomentUuids: Seq[UUID]): Int
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ImagedMomentDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ImagedMomentDAO.scala
@@ -16,11 +16,9 @@
 
 package org.mbari.annosaurus.repository
 
-import org.mbari.annosaurus.PersistentObject
 import org.mbari.annosaurus.domain.WindowRequest
-import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
-import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 import org.mbari.annosaurus.repository.jpa.entity.extensions.*
+import org.mbari.annosaurus.repository.jpa.entity.{IPersistentObject, ImagedMomentEntity}
 import org.mbari.vcr4j.time.Timecode
 
 import java.time.{Duration, Instant}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/IndexDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/IndexDAO.scala
@@ -16,9 +16,9 @@
 
 package org.mbari.annosaurus.repository
 
-import java.util.UUID
-
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
+
+import java.util.UUID
 
 /**
  * Special DAO for fetching just the index information from the ImagedMomemnts

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/IndexDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/IndexDAO.scala
@@ -20,18 +20,17 @@ import java.util.UUID
 
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 
-/** Special DAO for fetching just the index information from the ImagedMomemnts
-  *
-  * @author
-  *   Brian Schlining
-  * @since 2019-02-08T08:53:00
-  */
-trait IndexDAO[T <: IPersistentObject] extends DAO[T] {
+/**
+ * Special DAO for fetching just the index information from the ImagedMomemnts
+ *
+ * @author
+ *   Brian Schlining
+ * @since 2019-02-08T08:53:00
+ */
+trait IndexDAO[T <: IPersistentObject] extends DAO[T]:
 
     def findByVideoReferenceUuid(
         videoReferenceUuid: UUID,
         limit: Option[Int] = None,
         offset: Option[Int] = None
     ): Iterable[T]
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/NotFoundInDatastoreException.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/NotFoundInDatastoreException.scala
@@ -16,10 +16,11 @@
 
 package org.mbari.annosaurus.repository
 
-/** Marker Exception for when you do a query (such as by primary key) and a match is not found.
-  *
-  * @author
-  *   Brian Schlining
-  * @since 2016-05-26T10:11:00
-  */
+/**
+ * Marker Exception for when you do a query (such as by primary key) and a match is not found.
+ *
+ * @author
+ *   Brian Schlining
+ * @since 2016-05-26T10:11:00
+ */
 class NotFoundInDatastoreException(msg: String) extends RuntimeException(msg)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ObservationDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ObservationDAO.scala
@@ -16,9 +16,8 @@
 
 package org.mbari.annosaurus.repository
 
-import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
-import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
 import org.mbari.annosaurus.domain.{ConcurrentRequest, MultiRequest}
+import org.mbari.annosaurus.repository.jpa.entity.{IPersistentObject, ObservationEntity}
 
 import java.time.{Duration, Instant}
 import java.util.UUID

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ObservationDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/ObservationDAO.scala
@@ -23,11 +23,12 @@ import org.mbari.annosaurus.domain.{ConcurrentRequest, MultiRequest}
 import java.time.{Duration, Instant}
 import java.util.UUID
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T16:10:00
-  */
-trait ObservationDAO[T <: IPersistentObject] extends DAO[T] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T16:10:00
+ */
+trait ObservationDAO[T <: IPersistentObject] extends DAO[T]:
 
     def newPersistentObject(
         concept: String,
@@ -79,19 +80,22 @@ trait ObservationDAO[T <: IPersistentObject] extends DAO[T] {
 
     def countByMultiRequest(request: MultiRequest): Long
 
-    /** @return
-      *   Order sequence of all concept names used
-      */
+    /**
+     * @return
+     *   Order sequence of all concept names used
+     */
     def findAllConcepts(): Seq[String]
 
-    /** @return
-      *   Ordered sequence of all activities used.
-      */
+    /**
+     * @return
+     *   Ordered sequence of all activities used.
+     */
     def findAllActivities(): Seq[String]
 
-    /** @return
-      *   Ordered sequence of all groups used.
-      */
+    /**
+     * @return
+     *   Ordered sequence of all groups used.
+     */
     def findAllGroups(): Seq[String]
 
     def findAllConceptsByVideoReferenceUUID(uuid: UUID): Seq[String]
@@ -106,14 +110,13 @@ trait ObservationDAO[T <: IPersistentObject] extends DAO[T] {
 
     def updateConcept(oldName: String, newName: String): Int
 
-    /** Move an observation to a different imaged moment efficeintly
-      * @param imagedMomentUuid
-      *   The image moment we want to move to
-      * @param observationUuid
-      *   The observation to move
-      * @return
-      *   The number of records affected. Should be 1
-      */
+    /**
+     * Move an observation to a different imaged moment efficeintly
+     * @param imagedMomentUuid
+     *   The image moment we want to move to
+     * @param observationUuid
+     *   The observation to move
+     * @return
+     *   The number of records affected. Should be 1
+     */
     def changeImageMoment(imagedMomentUuid: UUID, observationUuid: UUID): Int
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepository.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepository.scala
@@ -33,33 +33,35 @@ class AnalysisRepository(entityManagerFactory: EntityManagerFactory) {
     def depthHistogram(constraints: QueryConstraints, binSizeMeters: Int = 50): DepthHistogram = {
         val select                       = DepthHistogramSQL.selectFromBinSize(binSizeMeters)
         val entityManager: EntityManager = entityManagerFactory.createEntityManager()
-        val transaction = entityManager.getTransaction()
+        val transaction                  = entityManager.getTransaction()
         transaction.begin()
         val query                        = QueryConstraintsSqlBuilder.toQuery(constraints, entityManager, select, "")
         query.setHint(QueryHints.HINT_READONLY, true)
         val results                      = query.getResultList.iterator().next()
         transaction.commit()
         entityManager.close()
-        val values                       = results.asInstanceOf[Array[Object]]
+        val values                       = results
+            .asInstanceOf[Array[Object]]
             .map(s => s.asInt.getOrElse(0))
             .toList
 
-        val binsMin                      = (0 until DepthHistogramSQL.MaxDepth by binSizeMeters).toList
-        val binsMax                      = binsMin.map(_ + binSizeMeters)
+        val binsMin = (0 until DepthHistogramSQL.MaxDepth by binSizeMeters).toList
+        val binsMax = binsMin.map(_ + binSizeMeters)
         DepthHistogram(binsMin, binsMax, values)
     }
 
     def timeHistogram(constraints: QueryConstraints, binSizeDays: Int = 30): TimeHistogram = {
-        val start = constraints.minTimestamp.getOrElse(TimeHistogramSQL.MinTime)
+        val start                        = constraints.minTimestamp.getOrElse(TimeHistogramSQL.MinTime)
         val now                          = constraints.maxTimestamp.getOrElse(Instant.now())
         val select                       = TimeHistogramSQL.selectFromBinSize(start, now, binSizeDays)
         val entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query                        = QueryConstraintsSqlBuilder.toQuery(constraints, entityManager, select, "")
         query.setHint(QueryHints.HINT_READONLY, true)
 //        println(query)
-        val results = query.getResultList.iterator().next()
+        val results                      = query.getResultList.iterator().next()
         entityManager.close()
-        val values  = results.asInstanceOf[Array[Object]]
+        val values                       = results
+            .asInstanceOf[Array[Object]]
             .map(s => s.asInt.getOrElse(0))
             .toList
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepository.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepository.scala
@@ -31,12 +31,9 @@ class AnalysisRepository(entityManagerFactory: EntityManagerFactory):
     def depthHistogram(constraints: QueryConstraints, binSizeMeters: Int = 50): DepthHistogram =
         val select                       = DepthHistogramSQL.selectFromBinSize(binSizeMeters)
         val entityManager: EntityManager = entityManagerFactory.createEntityManager()
-        val transaction                  = entityManager.getTransaction()
-        transaction.begin()
         val query                        = QueryConstraintsSqlBuilder.toQuery(constraints, entityManager, select, "")
         query.setHint(QueryHints.HINT_READONLY, true)
         val results                      = query.getResultList.iterator().next()
-        transaction.commit()
         entityManager.close()
         val values                       = results
             .asInstanceOf[Array[Object]]
@@ -54,7 +51,6 @@ class AnalysisRepository(entityManagerFactory: EntityManagerFactory):
         val entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query                        = QueryConstraintsSqlBuilder.toQuery(constraints, entityManager, select, "")
         query.setHint(QueryHints.HINT_READONLY, true)
-//        println(query)
         val results                      = query.getResultList.iterator().next()
         entityManager.close()
         val values                       = results

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepository.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepository.scala
@@ -17,14 +17,12 @@
 package org.mbari.annosaurus.repository.jdbc
 
 import jakarta.persistence.{EntityManager, EntityManagerFactory}
-
-import org.mbari.annosaurus.domain.{DepthHistogram, TimeHistogram}
+import org.hibernate.jpa.QueryHints
+import org.mbari.annosaurus.domain.{DepthHistogram, QueryConstraints, TimeHistogram}
 import org.slf4j.LoggerFactory
 
-import scala.jdk.CollectionConverters.*
 import java.time.Instant
-import org.mbari.annosaurus.domain.QueryConstraints
-import org.hibernate.jpa.QueryHints
+import scala.jdk.CollectionConverters.*
 
 class AnalysisRepository(entityManagerFactory: EntityManagerFactory):
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepository.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepository.scala
@@ -21,16 +21,16 @@ import jakarta.persistence.{EntityManager, EntityManagerFactory}
 import org.mbari.annosaurus.domain.{DepthHistogram, TimeHistogram}
 import org.slf4j.LoggerFactory
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import java.time.Instant
 import org.mbari.annosaurus.domain.QueryConstraints
 import org.hibernate.jpa.QueryHints
 
-class AnalysisRepository(entityManagerFactory: EntityManagerFactory) {
+class AnalysisRepository(entityManagerFactory: EntityManagerFactory):
 
     private val log = LoggerFactory.getLogger(getClass)
 
-    def depthHistogram(constraints: QueryConstraints, binSizeMeters: Int = 50): DepthHistogram = {
+    def depthHistogram(constraints: QueryConstraints, binSizeMeters: Int = 50): DepthHistogram =
         val select                       = DepthHistogramSQL.selectFromBinSize(binSizeMeters)
         val entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val transaction                  = entityManager.getTransaction()
@@ -48,9 +48,8 @@ class AnalysisRepository(entityManagerFactory: EntityManagerFactory) {
         val binsMin = (0 until DepthHistogramSQL.MaxDepth by binSizeMeters).toList
         val binsMax = binsMin.map(_ + binSizeMeters)
         DepthHistogram(binsMin, binsMax, values)
-    }
 
-    def timeHistogram(constraints: QueryConstraints, binSizeDays: Int = 30): TimeHistogram = {
+    def timeHistogram(constraints: QueryConstraints, binSizeDays: Int = 30): TimeHistogram =
         val start                        = constraints.minTimestamp.getOrElse(TimeHistogramSQL.MinTime)
         val now                          = constraints.maxTimestamp.getOrElse(Instant.now())
         val select                       = TimeHistogramSQL.selectFromBinSize(start, now, binSizeDays)
@@ -74,7 +73,3 @@ class AnalysisRepository(entityManagerFactory: EntityManagerFactory) {
             .map(_.plusMillis(intervalMillis))
 
         TimeHistogram(binsMin, binsMax, values)
-
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AncillaryDatumExt.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AncillaryDatumExt.scala
@@ -17,6 +17,7 @@
 package org.mbari.annosaurus.repository.jdbc
 
 import org.mbari.annosaurus.repository.jpa.entity.CachedAncillaryDatumEntity
+
 import java.util.UUID
 
 class AncillaryDatumExt extends CachedAncillaryDatumEntity:

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AncillaryDatumExt.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AncillaryDatumExt.scala
@@ -19,6 +19,5 @@ package org.mbari.annosaurus.repository.jdbc
 import org.mbari.annosaurus.repository.jpa.entity.CachedAncillaryDatumEntity
 import java.util.UUID
 
-class AncillaryDatumExt extends CachedAncillaryDatumEntity {
+class AncillaryDatumExt extends CachedAncillaryDatumEntity:
     var imagedMomentUuid: UUID = scala.compiletime.uninitialized
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AncillaryDatumSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AncillaryDatumSQL.scala
@@ -16,10 +16,9 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
+import org.mbari.annosaurus.domain.{Annotation, CachedAncillaryDatum}
+
 import java.util.UUID
-import org.mbari.annosaurus.domain.CachedAncillaryDatum
-import org.mbari.annosaurus.domain.Annotation
-import org.mbari.annosaurus.domain.CachedAncillaryDatumSC
 
 object AncillaryDatumSQL:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AncillaryDatumSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AncillaryDatumSQL.scala
@@ -21,12 +21,11 @@ import org.mbari.annosaurus.domain.CachedAncillaryDatum
 import org.mbari.annosaurus.domain.Annotation
 import org.mbari.annosaurus.domain.CachedAncillaryDatumSC
 
-object AncillaryDatumSQL {
+object AncillaryDatumSQL:
 
-    def resultListToAnncillaryData(rows: List[?]): Seq[CachedAncillaryDatum] = {
-        for {
-            row <- rows
-        } yield {
+    def resultListToAnncillaryData(rows: List[?]): Seq[CachedAncillaryDatum] =
+        for row <- rows
+        yield
             val xs = row.asInstanceOf[Array[Object]]
 
             CachedAncillaryDatum(
@@ -50,11 +49,9 @@ object AncillaryDatumSQL {
                 lightTransmission = xs(17).asFloat,
                 imagedMomentUuid = xs(18).asUUID
             )
-        }
-    }
 
     private def toDouble(obj: Number): Option[Double] =
-        if (obj != null) Some(obj.doubleValue())
+        if obj != null then Some(obj.doubleValue())
         else None
 
     val SELECT: String =
@@ -115,12 +112,8 @@ object AncillaryDatumSQL {
     def join(
         annotations: Seq[Annotation],
         data: Seq[CachedAncillaryDatum]
-    ): Seq[Annotation] = {
+    ): Seq[Annotation] =
         for a <- annotations
-        yield data.find(_.imagedMomentUuid == a.imagedMomentUuid) match {
+        yield data.find(_.imagedMomentUuid == a.imagedMomentUuid) match
             case Some(d) => a.copy(ancillaryData = Some(d))
             case None    => a
-        }
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnnotationSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnnotationSQL.scala
@@ -16,12 +16,10 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
-import java.time.Duration
-import java.util.UUID
-import java.sql.Timestamp
-import org.mbari.vcr4j.time.Timecode
 import org.mbari.annosaurus.domain.Annotation
+
 import java.time.Instant
+import java.util.UUID
 
 /**
  * Object that contains the SQL and methods to build annotations

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnnotationSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnnotationSQL.scala
@@ -23,14 +23,14 @@ import org.mbari.vcr4j.time.Timecode
 import org.mbari.annosaurus.domain.Annotation
 import java.time.Instant
 
-/** Object that contains the SQL and methods to build annotations
-  */
-object AnnotationSQL {
+/**
+ * Object that contains the SQL and methods to build annotations
+ */
+object AnnotationSQL:
 
-    def resultListToAnnotations(rows: List[?]): Seq[Annotation] = {
-        for {
-            row <- rows
-        } yield {
+    def resultListToAnnotations(rows: List[?]): Seq[Annotation] =
+        for row <- rows
+        yield
             val xs = row.asInstanceOf[Array[Object]]
             Annotation(
                 imagedMomentUuid = xs(0).asUUID,
@@ -46,8 +46,6 @@ object AnnotationSQL {
                 observationTimestamp = xs(10).asInstant,
                 observer = xs(11).asString
             )
-        }
-    }
 
     val SELECT: String =
         """ SELECT DISTINCT
@@ -122,5 +120,3 @@ object AnnotationSQL {
 
     val byToConceptWithImages: String =
         SELECT + FROM_WITH_IMAGES_AND_ASSOCIATIONS + " WHERE ass.to_concept = ?" + ORDER
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AssociationSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AssociationSQL.scala
@@ -16,9 +16,9 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
+import org.mbari.annosaurus.domain.{Annotation, Association}
+
 import java.util.UUID
-import org.mbari.annosaurus.domain.Association
-import org.mbari.annosaurus.domain.Annotation
 
 // @deprecated("Use Association's NamedQueries instead", "2023-12-18")
 object AssociationSQL:

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AssociationSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/AssociationSQL.scala
@@ -21,12 +21,11 @@ import org.mbari.annosaurus.domain.Association
 import org.mbari.annosaurus.domain.Annotation
 
 // @deprecated("Use Association's NamedQueries instead", "2023-12-18")
-object AssociationSQL {
+object AssociationSQL:
 
-    def resultListToAssociations(rows: List[?]): Seq[Association] = {
-        for {
-            row <- rows
-        } yield {
+    def resultListToAssociations(rows: List[?]): Seq[Association] =
+        for row <- rows
+        yield
             val xs               = row.asInstanceOf[Array[Object]]
             val uuid             = xs(0).asUUID
             val observationUuid  = xs(1).asUUID
@@ -58,19 +57,16 @@ object AssociationSQL {
             // // a.mimeType = xs(5).toString
             // a.imagedMomentUuid = UUID.fromString(xs(6).toString)
             // a
-        }
-    }
 
     def join(
         annotations: Seq[Annotation],
         associations: Seq[Association]
     ): Seq[Annotation] =
         for a <- annotations
-        yield {
+        yield
             val matches = associations.filter(anno => anno.observationUuid == a.observationUuid)
-            if (matches.isEmpty) a
+            if matches.isEmpty then a
             else a.copy(associations = a.associations.appendedAll(matches))
-        }
 
     val SELECT: String =
         """ SELECT DISTINCT
@@ -126,5 +122,3 @@ object AssociationSQL {
       |     obs.uuid = associations.observation_uuid
       | )
       |""".stripMargin
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/DepthHistogramSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/DepthHistogramSQL.scala
@@ -16,19 +16,15 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
-object DepthHistogramSQL {
+object DepthHistogramSQL:
 
     val MaxDepth: Int = 4000
 
-    def selectFromBinSize(binSizeMeters: Int = 50): String = {
-        val xs = for (i <- 0 until MaxDepth by binSizeMeters) yield {
+    def selectFromBinSize(binSizeMeters: Int = 50): String =
+        val xs = for (i <- 0 until MaxDepth by binSizeMeters) yield
             val j = i + binSizeMeters
             s"COUNT(CASE WHEN ad.depth_meters >= $i AND ad.depth_meters < $j THEN 1 END) AS \"$i-$j\""
-        }
 
         s"""SELECT
        |  ${xs.mkString(",\n  ")}
        |""".stripMargin
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ImageReferenceSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ImageReferenceSQL.scala
@@ -16,10 +16,9 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
+import org.mbari.annosaurus.domain.{Annotation, ImageReference}
+
 import java.util.UUID
-import java.net.URI
-import org.mbari.annosaurus.domain.ImageReference
-import org.mbari.annosaurus.domain.Annotation
 
 object ImageReferenceSQL:
     val SELECT: String =

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ImageReferenceSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ImageReferenceSQL.scala
@@ -21,7 +21,7 @@ import java.net.URI
 import org.mbari.annosaurus.domain.ImageReference
 import org.mbari.annosaurus.domain.Annotation
 
-object ImageReferenceSQL {
+object ImageReferenceSQL:
     val SELECT: String =
         """ SELECT DISTINCT
       |  ir.uuid AS image_reference_uuid,
@@ -68,10 +68,9 @@ object ImageReferenceSQL {
       | )
       |""".stripMargin
 
-    def resultListToImageReferences(rows: List[?]): Seq[ImageReference] = {
-        for {
-            row <- rows
-        } yield {
+    def resultListToImageReferences(rows: List[?]): Seq[ImageReference] =
+        for row <- rows
+        yield
             val xs = row.asInstanceOf[Array[Object]]
             ImageReference(
                 url = xs(4).asUrl.orNull,
@@ -83,18 +82,12 @@ object ImageReferenceSQL {
                 imagedMomentUuid = xs(6).asUUID
             )
 
-        }
-    }
-
     def join(
         annotations: Seq[Annotation],
         images: Seq[ImageReference]
-    ): Seq[Annotation] = {
+    ): Seq[Annotation] =
         for a <- annotations
         yield
             val matches = images.filter(_.imagedMomentUuid == a.imagedMomentUuid)
-            if (matches.isEmpty) a
+            if matches.isEmpty then a
             else a.copy(imageReferences = a.imageReferences.appendedAll(matches))
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ImagedMomentSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ImagedMomentSQL.scala
@@ -23,7 +23,7 @@ import java.sql.Timestamp
 import org.mbari.vcr4j.time.Timecode
 import java.net.URI
 
-object ImagedMomentSQL {
+object ImagedMomentSQL:
 
     /** recorded_timestamp is used for sorting, but not returned in the result set */
     val SELECT_UUID: String = "SELECT DISTINCT im.uuid, im.recorded_timestamp "
@@ -70,10 +70,9 @@ object ImagedMomentSQL {
     val deleteByVideoReferenceUuid: String =
         "DELETE FROM imaged_moments WHERE video_reference_uuid = ?"
 
-    def resultListToImages(rows: List[?]): Seq[Image] = {
-        for {
-            row <- rows
-        } yield {
+    def resultListToImages(rows: List[?]): Seq[Image] =
+        for row <- rows
+        yield
             val xs = row.asInstanceOf[Array[Object]]
             Image(
                 imagedMomentUuid = xs(0).asUUID.orNull,
@@ -88,8 +87,3 @@ object ImagedMomentSQL {
                 url = xs(9).asUrl,
                 imageReferenceUuid = xs(10).asUUID.orNull
             )
-
-        }
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ImagedMomentSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ImagedMomentSQL.scala
@@ -17,11 +17,8 @@
 package org.mbari.annosaurus.repository.jdbc
 
 import org.mbari.annosaurus.domain.Image
+
 import java.util.UUID
-import java.time.Duration
-import java.sql.Timestamp
-import org.mbari.vcr4j.time.Timecode
-import java.net.URI
 
 object ImagedMomentSQL:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepository.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepository.scala
@@ -23,8 +23,11 @@ import jakarta.persistence.{EntityManager, EntityManagerFactory, Query}
 import scala.jdk.CollectionConverters.*
 import scala.util.control.NonFatal
 import org.mbari.annosaurus.domain.{Annotation, ConcurrentRequest, DeleteCount, GeographicRange, Image, MultiRequest, ObservationsUpdate, QueryConstraints}
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Logging.{given, *}
 import org.mbari.annosaurus.repository.jpa.extensions.*
+// import org.mbari.annosaurus.etc.jpa.EntityManagers.*
+import jakarta.persistence.QueryHint
+import org.hibernate.jpa.QueryHints
 
 /** Database access (read-only) provider that uses SQL for fast lookups. WHY? JPA makes about 1 +
   * (rows * 4) database requests when looking up annotations. For 1000 rows that 4001 database calls
@@ -64,6 +67,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
             //     q.setParameter(1, videoReferenceUuid)
             // }
             // else {
+            q.setHint(QueryHints.HINT_READONLY, true)
             q.setParameter(1, videoReferenceUuid.toString)
             // }
         })
@@ -98,44 +102,52 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
 
     def findByQueryConstraint(constraints: QueryConstraints): Seq[Annotation] = {
         given entityManager: EntityManager = entityManagerFactory.createEntityManager()
-        val query1                         = QueryConstraintsSqlBuilder.toQuery(constraints, entityManager)
-        val r1                             = query1.getResultList.asScala.toList
-        val annotations                    = AnnotationSQL.resultListToAnnotations(r1)
-        val resolvedAnnotations            = executeQueryForAnnotations(annotations, constraints.includeData)
-        entityManager.close()
-        resolvedAnnotations.map(_.removeForeignKeys())
+        entityManagerFactory.createEntityManager().runTransactionSync { entityManager =>
+            given EntityManager = entityManager
+            val query1                         = QueryConstraintsSqlBuilder.toQuery(constraints, entityManager)
+            val r1                             = query1.getResultList.asScala.toList
+            val annotations                    = AnnotationSQL.resultListToAnnotations(r1)
+            val resolvedAnnotations            = executeQueryForAnnotations(annotations, constraints.includeData)
+            resolvedAnnotations.map(_.removeForeignKeys())
+        } 
     }
 
     def countByQueryConstraint(constraints: QueryConstraints): Int = {
-        given entityManager: EntityManager = entityManagerFactory.createEntityManager()
-        val query                          = QueryConstraintsSqlBuilder.toCountQuery(constraints, entityManager)
-        // Postgresql returns a Long, Everything else returns an Int
-        val count                          = query.getResultList.get(0).toString().toInt
-        entityManager.close()
-        count
+        entityManagerFactory.createEntityManager().runTransactionSync { entityManager =>
+            given EntityManager = entityManager
+            val query                          = QueryConstraintsSqlBuilder.toCountQuery(constraints, entityManager)
+            query.setHint(QueryHints.HINT_READONLY, true)
+            // Postgresql returns a Long, Everything else returns an Int
+            val count                          = query.getResultList.get(0).toString().toInt
+            entityManager.close()
+            count
+        }
     }
 
     def findGeographicRangeByQueryConstraint(
         constraints: QueryConstraints
     ): Option[GeographicRange] = {
-        given entityManager: EntityManager = entityManagerFactory.createEntityManager()
-        val query                          = QueryConstraintsSqlBuilder.toGeographicRangeQuery(constraints, entityManager)
-        // Queries return java.util.List[Array[Object]]
-        val count                          = query.getResultList.asScala.toList
-        if (count.nonEmpty) {
-            val head = count.head.asInstanceOf[Array[?]]
-            Some(
-                GeographicRange(
-                    head(0).toString.toDouble,
-                    head(1).toString.toDouble,
-                    head(2).toString.toDouble,
-                    head(3).toString.toDouble,
-                    head(4).toString.toDouble,
-                    head(5).toString.toDouble
+        entityManagerFactory.createEntityManager().runTransactionSync { entityManager =>
+            given EntityManager = entityManager
+            val query                          = QueryConstraintsSqlBuilder.toGeographicRangeQuery(constraints, entityManager)
+            query.setHint(QueryHints.HINT_READONLY, true)
+            // Queries return java.util.List[Array[Object]]
+            val count                          = query.getResultList.asScala.toList
+            if (count.nonEmpty) {
+                val head = count.head.asInstanceOf[Array[?]]
+                Some(
+                    GeographicRange(
+                        head(0).toString.toDouble,
+                        head(1).toString.toDouble,
+                        head(2).toString.toDouble,
+                        head(3).toString.toDouble,
+                        head(4).toString.toDouble,
+                        head(5).toString.toDouble
+                    )
                 )
-            )
-        }
-        else None
+            }
+            else None
+        } 
     }
 
     def findAll(
@@ -144,22 +156,25 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
         includeAncillaryData: Boolean = false
     ): Seq[Annotation] = {
 
-        given entityManager: EntityManager = entityManagerFactory.createEntityManager()
-        val query1                         = entityManager.createNativeQuery(AnnotationSQL.all)
-        limit.foreach(query1.setMaxResults)
-        offset.foreach(query1.setFirstResult)
+        entityManagerFactory.createEntityManager().runTransactionSync { entityManager =>
+            given EntityManager = entityManager
+            val query1                         = entityManager.createNativeQuery(AnnotationSQL.all)
+            limit.foreach(query1.setMaxResults)
+            offset.foreach(query1.setFirstResult)
 
-        val r1 = query1.getResultList.asScala.toList
-        val a1 = AnnotationSQL.resultListToAnnotations(r1)
-        val a2 = executeQueryForAnnotations(a1, includeAncillaryData)
-        entityManager.close()
-        a2
+            val r1 = query1.getResultList.asScala.toList
+            val a1 = AnnotationSQL.resultListToAnnotations(r1)
+            val a2 = executeQueryForAnnotations(a1, includeAncillaryData)
+            entityManager.close()
+            a2
+        } 
 
     }
 
     def countAll(): Long = {
         given entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query                          = entityManager.createNativeQuery(ObservationSQL.countAll)
+        query.setHint(QueryHints.HINT_READONLY, true)
         // This will throw and exception if nothing is returned. That's ok.
         val count                          = query.getSingleResult.asLong.get
         entityManager.close()
@@ -169,6 +184,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
     def countImagesByVideoReferenceUuid(videoReferenceUuid: UUID): Long = {
         given entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query                          = entityManager.createNativeQuery(ImageReferenceSQL.countByVideoReferenceUuid)
+        query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, videoReferenceUuid.toString())
         // This will throw and exception if nothing is returned. That's ok.
         // SQL Server returns Int, Postgresql returns Long
@@ -220,6 +236,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
         )
 
         queries.foreach(q => {
+            q.setHint(QueryHints.HINT_READONLY, true)
             q.setParameter(1, videoReferenceUuid.toString)
             q.setParameter(2, startTimestamp)
             q.setParameter(3, endTimestamp)
@@ -251,6 +268,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
             .map(entityManager.createNativeQuery)
 
         queries.foreach(q => {
+            q.setHint(QueryHints.HINT_READONLY, true)
             q.setParameter(1, request.startTimestamp)
             q.setParameter(2, request.endTimestamp)
             // q.setParameter(1, Timestamp.from(request.startTimestamp))
@@ -279,6 +297,10 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
         ).map(sql => inClause(sql, uuids))
             .map(entityManager.createNativeQuery)
 
+        queries.foreach(q => {
+            q.setHint(QueryHints.HINT_READONLY, true)
+        })
+
         val annos =
             executeQuery(queries(0), queries(1), queries(2), limit, offset, includeAncillaryData)
         entityManager.close()
@@ -294,6 +316,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
         given entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query1                         = entityManager.createNativeQuery(AnnotationSQL.byConcept)
         query1.setParameter(1, concept)
+        query1.setHint(QueryHints.HINT_READONLY, true)
         limit.foreach(query1.setMaxResults)
         offset.foreach(query1.setFirstResult)
 
@@ -312,6 +335,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
     ): Seq[Annotation] = {
         given entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query1                         = entityManager.createNativeQuery(AnnotationSQL.byConceptWithImages)
+        query1.setHint(QueryHints.HINT_READONLY, true)
         query1.setParameter(1, concept)
         limit.foreach(query1.setMaxResults)
         offset.foreach(query1.setFirstResult)
@@ -330,6 +354,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
     ): Seq[Annotation] = {
         given entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query1                         = entityManager.createNativeQuery(AnnotationSQL.byToConceptWithImages)
+        query1.setHint(QueryHints.HINT_READONLY, true)
         query1.setParameter(1, toConcept)
         limit.foreach(query1.setMaxResults)
         offset.foreach(query1.setFirstResult)
@@ -347,6 +372,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
     ): Seq[UUID] = {
         given entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query                          = entityManager.createNativeQuery(ImagedMomentSQL.byConceptWithImages)
+        query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, concept)
         limit.foreach(query.setMaxResults)
         offset.foreach(query.setFirstResult)
@@ -367,6 +393,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
     ): Seq[UUID] = {
         implicit val entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query                                 = entityManager.createNativeQuery(ImagedMomentSQL.byToConceptWithImages)
+        query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, toConcept)
         limit.foreach(query.setMaxResults)
         offset.foreach(query.setFirstResult)
@@ -387,6 +414,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
     ): Seq[Image] = {
         implicit val entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query                                 = entityManager.createNativeQuery(ImagedMomentSQL.byVideoReferenceUuid)
+        query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, videoReferenceUuid.toString)
         limit.foreach(query.setMaxResults)
         offset.foreach(query.setFirstResult)
@@ -403,6 +431,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
     ): Seq[Annotation] = {
         implicit val entityManager: EntityManager = entityManagerFactory.createEntityManager()
         val query                                 = entityManager.createNativeQuery(AssociationSQL.byLinkNameAndLinkValue)
+        query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, linkName)
         query.setParameter(2, linkValue)
         val results                               = query.getResultList.asScala.toList
@@ -430,6 +459,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
         val annotations = (for (im <- imUuids.grouped(200)) yield {
             val sql     = inClause(AnnotationSQL.byImagedMomentUuids, im)
             val query   = entityManager.createNativeQuery(sql)
+            query.setHint(QueryHints.HINT_READONLY, true)
             val results = query.getResultList.asScala.toList
             AnnotationSQL.resultListToAnnotations(results)
         }).flatten.toSeq
@@ -446,6 +476,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
         val assocTemp        = for (obs <- observationUuids.grouped(200)) yield {
             val sql2   = inClause(AssociationSQL.byObservationUuids, obs)
             val query2 = entityManager.createNativeQuery(sql2)
+            query2.setHint(QueryHints.HINT_READONLY, true)
             val r2     = query2.getResultList.asScala.toList
 
             // Remove the observationUuid and imagedMomentUuid from the association
@@ -458,6 +489,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
         val irTemp            = for (im <- imagedMomentUuids.grouped(200)) yield {
             val sql3   = inClause(ImageReferenceSQL.byImagedMomentUuids, im)
             val query3 = entityManager.createNativeQuery(sql3)
+            query3.setHint(QueryHints.HINT_READONLY, true)
             val r3     = query3.getResultList.asScala.toList
             ImageReferenceSQL.resultListToImageReferences(r3)
         }
@@ -487,6 +519,10 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
         offset: Option[Int] = None,
         includeAncillaryData: Boolean = false
     )(implicit entityManager: EntityManager): Seq[Annotation] = {
+
+        annotationQuery.setHint(QueryHints.HINT_READONLY, true)
+        associationQuery.setHint(QueryHints.HINT_READONLY, true)
+        imageReferenceQuery.setHint(QueryHints.HINT_READONLY, true)
 
         limit.foreach(annotationQuery.setMaxResults)
         offset.foreach(annotationQuery.setFirstResult)
@@ -530,6 +566,7 @@ class JdbcRepository(entityManagerFactory: EntityManagerFactory) {
             val ims   = annos.flatMap(_.imagedMomentUuid.map(_.toString())).distinct
             val sql   = inClause(AncillaryDatumSQL.byImagedMomentUuid, ims)
             val query = entityManager.createNativeQuery(sql)
+            query.setHint(QueryHints.HINT_READONLY, true)
             val rows  = query.getResultList.asScala.toList
             val data  = AncillaryDatumSQL.resultListToAnncillaryData(rows)
             AncillaryDatumSQL.join(annos, data)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepository.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepository.scala
@@ -28,7 +28,7 @@ import org.mbari.annosaurus.domain.{
     ObservationsUpdate,
     QueryConstraints
 }
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 import org.mbari.annosaurus.repository.jpa.extensions.*
 
 import java.time.Instant

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepository.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepository.scala
@@ -16,12 +16,8 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
-import java.time.Instant
-import java.util.UUID
 import jakarta.persistence.{EntityManager, EntityManagerFactory, Query}
-
-import scala.jdk.CollectionConverters.*
-import scala.util.control.NonFatal
+import org.hibernate.jpa.QueryHints
 import org.mbari.annosaurus.domain.{
     Annotation,
     ConcurrentRequest,
@@ -32,11 +28,13 @@ import org.mbari.annosaurus.domain.{
     ObservationsUpdate,
     QueryConstraints
 }
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+import org.mbari.annosaurus.etc.jdk.Logging.given
 import org.mbari.annosaurus.repository.jpa.extensions.*
-// import org.mbari.annosaurus.etc.jpa.EntityManagers.*
-import jakarta.persistence.QueryHint
-import org.hibernate.jpa.QueryHints
+
+import java.time.Instant
+import java.util.UUID
+import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
 
 /**
  * Database access (read-only) provider that uses SQL for fast lookups. WHY? JPA makes about 1 + (rows * 4) database

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ObservationSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ObservationSQL.scala
@@ -19,11 +19,12 @@ package org.mbari.annosaurus.repository.jdbc
 import jakarta.persistence.{EntityManager, Query}
 import org.mbari.annosaurus.domain.ObservationsUpdate
 
-/** @author
-  *   Brian Schlining
-  * @since 2019-10-28T16:39:00
-  */
-object ObservationSQL {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2019-10-28T16:39:00
+ */
+object ObservationSQL:
 
     val countAll: String = "SELECT COUNT(*) FROM observations"
 
@@ -92,5 +93,3 @@ object ObservationSQL {
             :: (updateActivity -> update.activity)
             :: Nil
         params.flatMap(p => build(p._1, p._2))
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ObservationSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/ObservationSQL.scala
@@ -78,7 +78,7 @@ object ObservationSQL {
         // and then sets the parameter for the value
         def build(sql: String, value: Option[String]): Option[Query] =
             value.map { v =>
-                val sql2 = sql.replace("(?)", uuidsString)
+                val sql2  = sql.replace("(?)", uuidsString)
                 val query = entityManager.createNativeQuery(sql2)
                 query.setParameter(1, v)
                 query
@@ -87,17 +87,10 @@ object ObservationSQL {
         // Map of the sql and the value to set. We'll build a query for each value that
         // is not an Option
         val params = (updateObserver -> update.observer)
-            :: (updateGroup -> update.group)
-            :: (updateConcept -> update.concept)
+            :: (updateGroup    -> update.group)
+            :: (updateConcept  -> update.concept)
             :: (updateActivity -> update.activity)
             :: Nil
         params.flatMap(p => build(p._1, p._2))
-
-
-
-
-
-
-
 
 }

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/QueryConstraintsSqlBuilder.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/QueryConstraintsSqlBuilder.scala
@@ -18,7 +18,7 @@ package org.mbari.annosaurus.repository.jdbc
 
 import jakarta.persistence.{EntityManager, Query}
 import org.mbari.annosaurus.domain.QueryConstraints
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 
 import java.time.Instant
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/QueryConstraintsSqlBuilder.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/QueryConstraintsSqlBuilder.scala
@@ -24,26 +24,27 @@ import jakarta.persistence.Query
 import java.sql.Timestamp
 import org.mbari.annosaurus.etc.jdk.Logging.given
 
-object QueryConstraintsSqlBuilder {
+object QueryConstraintsSqlBuilder:
 
     private val log = System.getLogger(getClass.getName)
 
-    /** Generates a SQL template for use to build a query. It's not executable SQL though!
-      * @param qc
-      * @return
-      */
-    def toFromWhereSql(qc: QueryConstraints): String = {
-        import org.mbari.annosaurus.repository.jdbc.AnnotationSQL._
+    /**
+     * Generates a SQL template for use to build a query. It's not executable SQL though!
+     * @param qc
+     * @return
+     */
+    def toFromWhereSql(qc: QueryConstraints): String =
+        import org.mbari.annosaurus.repository.jdbc.AnnotationSQL.*
 
         val sqlConstraints = List(
-            if (qc.concepts.nonEmpty) Some("(obs.concept IN (A?) OR ass.to_concept IN (A?))")
+            if qc.concepts.nonEmpty then Some("(obs.concept IN (A?) OR ass.to_concept IN (A?))")
             else None,
-            if (qc.videoReferenceUuids.nonEmpty) Some("im.video_reference_uuid IN (B?)")
+            if qc.videoReferenceUuids.nonEmpty then Some("im.video_reference_uuid IN (B?)")
             else None,
-            if (qc.observers.nonEmpty) Some("obs.observer IN (C?)") else None,
-            if (qc.groups.nonEmpty) Some("obs.observation_group IN (D?)") else None,
-            if (qc.activities.nonEmpty) Some("obs.activity IN (E?)") else None,
-            if (qc.missionContacts.nonEmpty) Some("vri.mission_contact IN (F?)") else None,
+            if qc.observers.nonEmpty then Some("obs.observer IN (C?)") else None,
+            if qc.groups.nonEmpty then Some("obs.observation_group IN (D?)") else None,
+            if qc.activities.nonEmpty then Some("obs.activity IN (E?)") else None,
+            if qc.missionContacts.nonEmpty then Some("vri.mission_contact IN (F?)") else None,
             qc.minDepth.map(_ => "ad.depth_meters >= ?"),
             qc.maxDepth.map(_ => "ad.depth_meters < ?"),
             qc.minLon.map(_ => "ad.longitude >= ?"),
@@ -60,69 +61,61 @@ object QueryConstraintsSqlBuilder {
 
         FROM_WITH_ANCILLARY_DATA + " WHERE " + sqlConstraints.mkString(" AND ")
 
-    }
-
     private def toSql(
         qc: QueryConstraints,
         selectStatement: String,
         orderStatement: String = AnnotationSQL.ORDER
-    ): String = {
+    ): String =
         // import org.mbari.vars.annotation.dao.jdbc.AnnotationSQL._
         val fromWhere = toFromWhereSql(qc)
         selectStatement + fromWhere + orderStatement
-    }
 
-    private def toCountSql(qc: QueryConstraints): String = {
+    private def toCountSql(qc: QueryConstraints): String =
         val fromWhere = toFromWhereSql(qc)
         val select    = "SELECT COUNT(DISTINCT obs.uuid)"
         select + " " + fromWhere
-    }
 
-    def toCountQuery(qc: QueryConstraints, entityManager: EntityManager): Query = {
+    def toCountQuery(qc: QueryConstraints, entityManager: EntityManager): Query =
         val sql = toCountSql(qc)
         buildQuery(qc, entityManager, sql)
-    }
 
-    /** @param qc
-      * @param entityManager
-      * @return
-      */
+    /**
+     * @param qc
+     * @param entityManager
+     * @return
+     */
     def toQuery(
         qc: QueryConstraints,
         entityManager: EntityManager,
         selectStatement: String = AnnotationSQL.SELECT,
         orderStatment: String = AnnotationSQL.ORDER
-    ): Query = {
+    ): Query =
         val sql = toSql(qc, selectStatement, orderStatment)
         log.atDebug.log(() => "SQL: " + sql)
         buildQuery(qc, entityManager, sql)
-    }
 
-    private def toGeographicRangeSql(qc: QueryConstraints): String = {
+    private def toGeographicRangeSql(qc: QueryConstraints): String =
         val fromWhere = toFromWhereSql(qc) +
             " AND ad.longitude IS NOT NULL AND ad.latitude IS NOT NULL AND ad.depth_meters IS NOT NULL"
         val select    =
             "SELECT min(ad.latitude), max(ad.latitude), min(ad.longitude), max(ad.longitude), min(ad.depth_meters), max(ad.depth_meters) "
         select + " " + fromWhere
-    }
 
-    def toGeographicRangeQuery(qc: QueryConstraints, entityManager: EntityManager): Query = {
+    def toGeographicRangeQuery(qc: QueryConstraints, entityManager: EntityManager): Query =
         val sql = toGeographicRangeSql(qc)
         buildQuery(qc, entityManager, sql)
-    }
 
     private def buildQuery(
         qc: QueryConstraints,
         entityManager: EntityManager,
         base: String
-    ): Query = {
+    ): Query =
 
         // JPA doesn't handle in clauses well. So this is a cludge
         def replaceInClause[A](xs: Iterable[A], sql: String, target: String): String =
-            if (xs.nonEmpty) {
+            if xs.nonEmpty then
                 val s = xs.mkString("('", "','", "')")
                 sql.replace(target, s)
-            }
             else sql
 
         val a   = replaceInClause(qc.concepts, base, "(A?)")
@@ -149,15 +142,8 @@ object QueryConstraintsSqlBuilder {
             qc.missionId
         ).flatten
         val query  = entityManager.createNativeQuery(sql)
-        for {
-            i <- params.indices
-        } {
-            query.setParameter(i + 1, params(i))
-        }
+        for i <- params.indices
+        do query.setParameter(i + 1, params(i))
         query.setMaxResults(qc.limit.getOrElse(5000))
         query.setFirstResult(qc.offset.getOrElse(0))
         query
-
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/QueryConstraintsSqlBuilder.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/QueryConstraintsSqlBuilder.scala
@@ -16,13 +16,11 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
-import java.util.UUID
-import java.time.Instant
+import jakarta.persistence.{EntityManager, Query}
 import org.mbari.annosaurus.domain.QueryConstraints
-import jakarta.persistence.EntityManager
-import jakarta.persistence.Query
-import java.sql.Timestamp
 import org.mbari.annosaurus.etc.jdk.Logging.given
+
+import java.time.Instant
 
 object QueryConstraintsSqlBuilder:
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/QueryContraintsJpqlBuilder.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/QueryContraintsJpqlBuilder.scala
@@ -16,7 +16,7 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
-object QueryContraintsJpqlBuilder {
+object QueryContraintsJpqlBuilder:
 
     def buildJpql(select: JpqlSelect, from: JpqlFrom, where: JpqlWhere, order: JpqlOrder): String =
         s"$select $from $where $order"
@@ -24,7 +24,7 @@ object QueryContraintsJpqlBuilder {
     def buildJpql(select: JpqlSelect, from: JpqlFrom, order: JpqlOrder): String =
         s"$select $from $order"
 
-    object Annotation {
+    object Annotation:
 
         val Order: JpqlOrder = JpqlOrder("ORDER BY obs.observationTimestamp")
 
@@ -105,7 +105,3 @@ object QueryContraintsJpqlBuilder {
             JpqlWhere("WHERE a.toConcept = :toConcept AND ir.url IS NOT NULL"),
             Order
         )
-
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/TimeHistogramSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/TimeHistogramSQL.scala
@@ -16,6 +16,8 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
+import io.prometheus.metrics.shaded.com_google_protobuf_3_25_3.Timestamp
+
 import java.time.Instant
 
 object TimeHistogramSQL:

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/TimeHistogramSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/TimeHistogramSQL.scala
@@ -22,7 +22,11 @@ object TimeHistogramSQL {
 
     val MinTime = Instant.parse("1987-01-01T00:00:00Z")
 
-    def selectFromBinSize(minInstant: Instant, maxInstant: Instant, binSizeDays: Int = 30): String = {
+    def selectFromBinSize(
+        minInstant: Instant,
+        maxInstant: Instant,
+        binSizeDays: Int = 30
+    ): String = {
         val intervalMillis = binSizeDays * 24 * 60 * 60 * 1000L
         val start          = minInstant.toEpochMilli
         val end            = maxInstant.toEpochMilli

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/TimeHistogramSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/TimeHistogramSQL.scala
@@ -16,8 +16,6 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
-import io.prometheus.metrics.shaded.com_google_protobuf_3_25_3.Timestamp
-
 import java.time.Instant
 
 object TimeHistogramSQL:

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/TimeHistogramSQL.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/TimeHistogramSQL.scala
@@ -18,7 +18,7 @@ package org.mbari.annosaurus.repository.jdbc
 
 import java.time.Instant
 
-object TimeHistogramSQL {
+object TimeHistogramSQL:
 
     val MinTime = Instant.parse("1987-01-01T00:00:00Z")
 
@@ -26,22 +26,18 @@ object TimeHistogramSQL {
         minInstant: Instant,
         maxInstant: Instant,
         binSizeDays: Int = 30
-    ): String = {
+    ): String =
         val intervalMillis = binSizeDays * 24 * 60 * 60 * 1000L
         val start          = minInstant.toEpochMilli
         val end            = maxInstant.toEpochMilli
-        val xs             = for (i <- start to end by intervalMillis) yield {
+        val xs             = for (i <- start to end by intervalMillis) yield
             val j     = i + intervalMillis
 //            val date0 = new java.sql.Date(i)
 //            val date1 = new java.sql.Date(j)
             val date0 = Instant.ofEpochMilli(i)
             val date1 = Instant.ofEpochMilli(j)
             s"COUNT(CASE WHEN im.recorded_timestamp >= '$date0' AND im.recorded_timestamp < '$date1' THEN 1 END) AS \"$i-$j\""
-        }
 
         s"""SELECT
        |  ${xs.mkString(",\n  ")}
        |""".stripMargin
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/sql.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/sql.scala
@@ -22,9 +22,10 @@ import scala.util.Try
 import java.net.URL
 import java.net.URI
 
-/** This is a collection of explicit conversions to convert from java.sql.ResultSet to various
-  * types. This is used in the JdbcRepository and associatited SQL classes.
-  */
+/**
+ * This is a collection of explicit conversions to convert from java.sql.ResultSet to various types. This is used in the
+ * JdbcRepository and associatited SQL classes.
+ */
 extension (obj: Object)
     def asDouble: Option[Double]   = doubleConverter(obj)
     def asFloat: Option[Float]     = floatConverter(obj)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/sql.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jdbc/sql.scala
@@ -16,11 +16,10 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
+import java.net.{URI, URL}
 import java.time.Instant
 import java.util.UUID
 import scala.util.Try
-import java.net.URL
-import java.net.URI
 
 /**
  * This is a collection of explicit conversions to convert from java.sql.ResultSet to various types. This is used in the

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/AssociationDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/AssociationDAOImpl.scala
@@ -22,17 +22,18 @@ import jakarta.persistence.EntityManager
 import org.mbari.annosaurus.repository.AssociationDAO
 import org.mbari.annosaurus.repository.jpa.entity.{AssociationEntity, ConceptAssociationDTO}
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import org.mbari.annosaurus.domain.{ConceptAssociation, ConceptAssociationRequest}
 import org.mbari.annosaurus.repository.jdbc.*
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T17:11:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T17:11:00
+ */
 class AssociationDAOImpl(entityManager: EntityManager)
     extends BaseDAO[AssociationEntity](entityManager)
-    with AssociationDAO[AssociationEntity] {
+    with AssociationDAO[AssociationEntity]:
 
     override def newPersistentObject(): AssociationEntity = new AssociationEntity
 
@@ -41,14 +42,13 @@ class AssociationDAOImpl(entityManager: EntityManager)
         toConcept: Option[String],
         linkValue: Option[String],
         mimeType: Option[String]
-    ): AssociationEntity = {
+    ): AssociationEntity =
         val a = new AssociationEntity
         a.setLinkName(linkName)
         toConcept.foreach(a.setToConcept)
         linkValue.foreach(a.setLinkValue)
         mimeType.foreach(a.setMimeType)
         a
-    }
 
     override def newPersistentObject(association: AssociationEntity): AssociationEntity =
         AssociationEntity(association)
@@ -64,15 +64,14 @@ class AssociationDAOImpl(entityManager: EntityManager)
     override def findByLinkNameAndVideoReferenceUUID(
         linkName: String,
         videoReferenceUUID: UUID
-    ): Iterable[AssociationEntity] = {
+    ): Iterable[AssociationEntity] =
         findByLinkNameAndVideoReferenceUUIDAndConcept(linkName, videoReferenceUUID, None)
-    }
 
     def findByLinkNameAndVideoReferenceUUIDAndConcept(
         linkName: String,
         videoReferenceUUID: UUID,
         concept: Option[String] = None
-    ): Iterable[AssociationEntity] = {
+    ): Iterable[AssociationEntity] =
         // HACK We are experiencing performance issues with the JPQL query. This
         // version is native SQL. Faster, but type casting is not pretty
         val query  = entityManager.createNamedQuery("Association.findByLinkNameAndVideoReference")
@@ -104,15 +103,13 @@ class AssociationDAOImpl(entityManager: EntityManager)
             )
 
         // Filter for a particular concept name
-        concept match {
+        concept match
             case None    => tuples.map(_._2)
             case Some(c) => tuples.filter(_._1 == c).map(_._2)
-        }
-    }
 
     def findByConceptAssociationRequest(
         request: ConceptAssociationRequest
-    ): Iterable[ConceptAssociation] = {
+    ): Iterable[ConceptAssociation] =
 
         val xs = findByTypedNamedQuery[ConceptAssociationDTO](
             "Association.findByConceptAssociationRequest",
@@ -124,15 +121,13 @@ class AssociationDAOImpl(entityManager: EntityManager)
 
         xs.map(ConceptAssociation.fromDto)
 
-    }
-
     override def findAll(
         limit: Option[Int] = None,
         offset: Option[Int] = None
     ): Iterable[AssociationEntity] =
         findByNamedQuery("Association.findAll", limit = limit, offset = offset)
 
-    override def countByToConcept(toConcept: String): Long = {
+    override def countByToConcept(toConcept: String): Long =
         // val query = entityManager.createNativeQuery("MutableAssociation.countByToConcept")
         val query = entityManager.createNamedQuery("Association.countByToConcept")
         query.setParameter(1, toConcept)
@@ -142,12 +137,8 @@ class AssociationDAOImpl(entityManager: EntityManager)
             .map(_.asLong.getOrElse(0L))
             .head
 
-    }
-
-    override def updateToConcept(oldToConcept: String, newToConcept: String): Int = {
+    override def updateToConcept(oldToConcept: String, newToConcept: String): Int =
         val query = entityManager.createNamedQuery("Association.updateToConcept")
         query.setParameter(1, newToConcept)
         query.setParameter(2, oldToConcept)
         query.executeUpdate()
-    }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/AssociationDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/AssociationDAOImpl.scala
@@ -16,15 +16,14 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import java.util.UUID
 import jakarta.persistence.EntityManager
-
+import org.mbari.annosaurus.domain.{ConceptAssociation, ConceptAssociationRequest}
 import org.mbari.annosaurus.repository.AssociationDAO
+import org.mbari.annosaurus.repository.jdbc.*
 import org.mbari.annosaurus.repository.jpa.entity.{AssociationEntity, ConceptAssociationDTO}
 
+import java.util.UUID
 import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.domain.{ConceptAssociation, ConceptAssociationRequest}
-import org.mbari.annosaurus.repository.jdbc.*
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAO.scala
@@ -32,24 +32,22 @@ import org.mbari.annosaurus.etc.jdk.Logging.given
 import java.lang.System.Logger.Level
 import org.hibernate.jpa.QueryHints
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-05-06T11:18:00
-  */
-abstract class BaseDAO[B <: IPersistentObject: ClassTag](val entityManager: EntityManager)
-    extends DAO[B] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-05-06T11:18:00
+ */
+abstract class BaseDAO[B <: IPersistentObject: ClassTag](val entityManager: EntityManager) extends DAO[B]:
 
     private val log = System.getLogger(getClass.getName)
 
-    if (log.isLoggable(Level.DEBUG)) {
+    if log.isLoggable(Level.DEBUG) then
         val props = entityManager.getProperties
-        if (props.containsKey(BaseDAO.JDBC_URL_KEY)) {
+        if props.containsKey(BaseDAO.JDBC_URL_KEY) then
             log.atDebug
                 .log(
                     s"Wrapping EntityManager with DAO for database: ${props.get(BaseDAO.JDBC_URL_KEY)}"
                 )
-        }
-    }
 
     def find(obj: B): Option[B] =
         obj.primaryKey.flatMap(pk => Option(entityManager.find(obj.getClass, pk)))
@@ -60,9 +58,8 @@ abstract class BaseDAO[B <: IPersistentObject: ClassTag](val entityManager: Enti
         limit: Option[Int] = None,
         offset: Option[Int] = None,
         readOnly: Boolean = false
-    ): List[B] = {
+    ): List[B] =
         findByTypedNamedQuery[B](name, namedParameters, limit, offset, readOnly)
-    }
 
     def findByTypedNamedQuery[C](
         name: String,
@@ -70,14 +67,10 @@ abstract class BaseDAO[B <: IPersistentObject: ClassTag](val entityManager: Enti
         limit: Option[Int] = None,
         offset: Option[Int] = None,
         readOnly: Boolean = false
-    ): List[C] = {
-        if (log.isLoggable(Level.DEBUG)) {
-            log.atDebug.log(s"JPA Query => $name using $namedParameters")
-        }
+    ): List[C] =
+        if log.isLoggable(Level.DEBUG) then log.atDebug.log(s"JPA Query => $name using $namedParameters")
         val query = entityManager.createNamedQuery(name)
-        if (readOnly) {
-            query.setHint(QueryHints.HINT_READONLY, true)
-        }
+        if readOnly then query.setHint(QueryHints.HINT_READONLY, true)
         limit.foreach(query.setMaxResults)
         offset.foreach(query.setFirstResult)
         namedParameters.foreach { case (a, b) => query.setParameter(a, b) }
@@ -86,28 +79,26 @@ abstract class BaseDAO[B <: IPersistentObject: ClassTag](val entityManager: Enti
             .asScala
             .toList
             .map(_.asInstanceOf[C])
-    }
 
-    /** Fetches the results as a stream. This better allows for fetching large sets and returning
-      * them as chunked responses.
-      * @param name
-      * @param namedParameters
-      * @param limit
-      * @param offset
-      * @return
-      */
+    /**
+     * Fetches the results as a stream. This better allows for fetching large sets and returning them as chunked
+     * responses.
+     * @param name
+     * @param namedParameters
+     * @param limit
+     * @param offset
+     * @return
+     */
     def streamByNamedQuery(
         name: String,
         namedParameters: Map[String, Any] = Map.empty,
         limit: Option[Int] = None,
         offset: Option[Int] = None,
         readOnly: Boolean = false
-    ): java.util.stream.Stream[B] = {
+    ): java.util.stream.Stream[B] =
 
         val query = entityManager.createNamedQuery(name)
-        if (readOnly) {
-            query.setHint(QueryHints.HINT_READONLY, true)
-        }
+        if readOnly then query.setHint(QueryHints.HINT_READONLY, true)
         limit.foreach(query.setMaxResults)
         offset.foreach(query.setFirstResult)
         namedParameters.foreach { case (a, b) => query.setParameter(a, b) }
@@ -115,31 +106,28 @@ abstract class BaseDAO[B <: IPersistentObject: ClassTag](val entityManager: Enti
             .getResultStream
             .map(b => b.asInstanceOf[B])
 
-    }
-
-    def executeNamedQuery(name: String, namedParameters: Map[String, Any] = Map.empty): Int = {
+    def executeNamedQuery(name: String, namedParameters: Map[String, Any] = Map.empty): Int =
         val query = entityManager.createNamedQuery(name)
         namedParameters.foreach { case (a, b) => query.setParameter(a, b) }
         query.executeUpdate()
-    }
 
-    /** Lookup entity by primary key. A DAO will only return entities of their type. Also, note that
-      * I had to use a little scala reflection magic here
-      *
-      * @param primaryKey
-      * @return
-      */
+    /**
+     * Lookup entity by primary key. A DAO will only return entities of their type. Also, note that I had to use a
+     * little scala reflection magic here
+     *
+     * @param primaryKey
+     * @return
+     */
     override def findByUUID(primaryKey: UUID): Option[B] =
         Option(entityManager.find(classTag[B].runtimeClass, primaryKey).asInstanceOf[B])
 
     override def deleteByUUID(primaryKey: UUID): Unit =
         findByUUID(primaryKey).foreach(delete)
 
-    override def runTransaction[R](fn: this.type => R)(implicit ec: ExecutionContext): Future[R] = {
+    override def runTransaction[R](fn: this.type => R)(implicit ec: ExecutionContext): Future[R] =
 
         def fn2(em: EntityManager): R = fn.apply(this)
         entityManager.runTransaction(fn2)
-    }
 
     override def create(entity: B): Unit = entityManager.persist(entity)
 
@@ -147,34 +135,24 @@ abstract class BaseDAO[B <: IPersistentObject: ClassTag](val entityManager: Enti
 
     override def delete(entity: B): Unit = entityManager.remove(entity)
 
-    def close(): Unit = if (entityManager.isOpen) {
-        entityManager.close()
-    }
+    def close(): Unit = if entityManager.isOpen then entityManager.close()
 
-    override def flush(): Unit = if (entityManager.isOpen) {
-        entityManager.flush()
-    }
+    override def flush(): Unit = if entityManager.isOpen then entityManager.flush()
 
-    override def commit(): Unit = if (entityManager.isOpen) {
-        entityManager.getTransaction.commit()
-    }
+    override def commit(): Unit = if entityManager.isOpen then entityManager.getTransaction.commit()
 
     override def isDetached(entity: B): Boolean =
         entity.primaryKey.isEmpty              // must not be transient
             && !entityManager.contains(entity) // must not be managed
             && find(entity).isDefined          // must not have been removed
 
-    def setUuidParameter(query: Query, position: Int, uuid: UUID): Query = {
+    def setUuidParameter(query: Query, position: Int, uuid: UUID): Query =
         // if (DatabaseProductName.isPostgreSQL()) {
         //     query.setParameter(position, uuid)
         // }
         // else {
         query.setParameter(position, uuid.toString.toLowerCase())
         // }
-    }
 
-}
-
-object BaseDAO {
+object BaseDAO:
     val JDBC_URL_KEY = "jakarta.persistence.jdbc.url"
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAO.scala
@@ -18,7 +18,7 @@ package org.mbari.annosaurus.repository.jpa
 
 import jakarta.persistence.{EntityManager, Query}
 import org.hibernate.jpa.QueryHints
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 import org.mbari.annosaurus.repository.DAO
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 import org.mbari.annosaurus.repository.jpa.entity.extensions.*

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAO.scala
@@ -28,7 +28,7 @@ import java.lang.System.Logger.Level
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.*
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.{classTag, ClassTag}
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAO.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAO.scala
@@ -16,21 +16,19 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import java.util.UUID
-import jakarta.persistence.{Entity, EntityManager, Query}
-
-import scala.jdk.CollectionConverters.*
-import scala.concurrent.{ExecutionContext, Future}
-import scala.reflect.ClassTag
-import scala.reflect.classTag
+import jakarta.persistence.{EntityManager, Query}
+import org.hibernate.jpa.QueryHints
+import org.mbari.annosaurus.etc.jdk.Logging.given
 import org.mbari.annosaurus.repository.DAO
 import org.mbari.annosaurus.repository.jpa.entity.IPersistentObject
 import org.mbari.annosaurus.repository.jpa.entity.extensions.*
 import org.mbari.annosaurus.repository.jpa.extensions.*
-import org.mbari.annosaurus.etc.jdk.Logging.given
 
 import java.lang.System.Logger.Level
-import org.hibernate.jpa.QueryHints
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters.*
+import scala.reflect.{ClassTag, classTag}
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedAncillaryDatumDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedAncillaryDatumDAOImpl.scala
@@ -16,11 +16,11 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import java.util.UUID
 import jakarta.persistence.EntityManager
-import org.mbari.annosaurus.etc.jdk.Numbers.*
 import org.mbari.annosaurus.repository.CachedAncillaryDatumDAO
 import org.mbari.annosaurus.repository.jpa.entity.{AncillaryDatumDTO, CachedAncillaryDatumEntity}
+
+import java.util.UUID
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedAncillaryDatumDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedAncillaryDatumDAOImpl.scala
@@ -22,13 +22,14 @@ import org.mbari.annosaurus.etc.jdk.Numbers.*
 import org.mbari.annosaurus.repository.CachedAncillaryDatumDAO
 import org.mbari.annosaurus.repository.jpa.entity.{AncillaryDatumDTO, CachedAncillaryDatumEntity}
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T17:12:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T17:12:00
+ */
 class CachedAncillaryDatumDAOImpl(entityManager: EntityManager)
     extends BaseDAO[CachedAncillaryDatumEntity](entityManager)
-    with CachedAncillaryDatumDAO[CachedAncillaryDatumEntity] {
+    with CachedAncillaryDatumDAO[CachedAncillaryDatumEntity]:
 
     override def newPersistentObject(): CachedAncillaryDatumEntity = new CachedAncillaryDatumEntity
 
@@ -50,7 +51,7 @@ class CachedAncillaryDatumDAOImpl(entityManager: EntityManager)
         phi: Option[Double] = None,
         theta: Option[Double] = None,
         psi: Option[Double] = None
-    ): CachedAncillaryDatumEntity = {
+    ): CachedAncillaryDatumEntity =
 
         val cad = new CachedAncillaryDatumEntity()
 
@@ -73,8 +74,6 @@ class CachedAncillaryDatumDAOImpl(entityManager: EntityManager)
         psi.foreach(cad.setPsi(_))
 
         cad
-
-    }
 
     override def newPersistentObject(
         datum: CachedAncillaryDatumEntity
@@ -107,9 +106,7 @@ class CachedAncillaryDatumDAOImpl(entityManager: EntityManager)
             Map("uuid" -> imagedMomentUuid)
         ).headOption
 
-    override def deleteByVideoReferenceUuid(videoReferenceUuid: UUID): Int = {
+    override def deleteByVideoReferenceUuid(videoReferenceUuid: UUID): Int =
         val query = entityManager.createNamedQuery("AncillaryDatum.deleteByVideoReferenceUuid")
         query.setParameter(1, videoReferenceUuid)
         query.executeUpdate()
-    }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOImpl.scala
@@ -21,16 +21,17 @@ import jakarta.persistence.EntityManager
 import org.mbari.annosaurus.repository.CachedVideoReferenceInfoDAO
 import org.mbari.annosaurus.repository.jpa.entity.CachedVideoReferenceInfoEntity
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import org.hibernate.jpa.QueryHints
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T17:15:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T17:15:00
+ */
 class CachedVideoReferenceInfoDAOImpl(entityManager: EntityManager)
     extends BaseDAO[CachedVideoReferenceInfoEntity](entityManager)
-    with CachedVideoReferenceInfoDAO[CachedVideoReferenceInfoEntity] {
+    with CachedVideoReferenceInfoDAO[CachedVideoReferenceInfoEntity]:
 
     override def newPersistentObject(): CachedVideoReferenceInfoEntity =
         new CachedVideoReferenceInfoEntity
@@ -84,5 +85,3 @@ class CachedVideoReferenceInfoDAOImpl(entityManager: EntityManager)
             .asScala
             .filter(_ != null)
             .map(_.toString)
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOImpl.scala
@@ -79,7 +79,8 @@ class CachedVideoReferenceInfoDAOImpl(entityManager: EntityManager)
     private def fetchUsing(namedQuery: String): Iterable[String] =
         val query = entityManager.createNamedQuery(namedQuery)
         query.setHint(QueryHints.HINT_READONLY, true)
-        query.getResultList
+        query
+            .getResultList
             .asScala
             .filter(_ != null)
             .map(_.toString)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOImpl.scala
@@ -16,13 +16,13 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import java.util.UUID
 import jakarta.persistence.EntityManager
+import org.hibernate.jpa.QueryHints
 import org.mbari.annosaurus.repository.CachedVideoReferenceInfoDAO
 import org.mbari.annosaurus.repository.jpa.entity.CachedVideoReferenceInfoEntity
 
+import java.util.UUID
 import scala.jdk.CollectionConverters.*
-import org.hibernate.jpa.QueryHints
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOImpl.scala
@@ -22,6 +22,7 @@ import org.mbari.annosaurus.repository.CachedVideoReferenceInfoDAO
 import org.mbari.annosaurus.repository.jpa.entity.CachedVideoReferenceInfoEntity
 
 import scala.jdk.CollectionConverters._
+import org.hibernate.jpa.QueryHints
 
 /** @author
   *   Brian Schlining
@@ -76,9 +77,9 @@ class CachedVideoReferenceInfoDAOImpl(entityManager: EntityManager)
         fetchUsing("VideoReferenceInfo.findAllMissionIDs")
 
     private def fetchUsing(namedQuery: String): Iterable[String] =
-        entityManager
-            .createNamedQuery(namedQuery)
-            .getResultList
+        val query = entityManager.createNamedQuery(namedQuery)
+        query.setHint(QueryHints.HINT_READONLY, true)
+        query.getResultList
             .asScala
             .filter(_ != null)
             .map(_.toString)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/DevelopmentDAOFactory.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/DevelopmentDAOFactory.scala
@@ -21,13 +21,14 @@ import jakarta.persistence.EntityManagerFactory
 
 import scala.util.Try
 
-/** DAOFactory for creating development database DAOs
-  *
-  * @author
-  *   Brian Schlining
-  * @since 2016-05-23T15:57:00
-  */
-object DevelopmentDAOFactory extends JPADAOFactory {
+/**
+ * DAOFactory for creating development database DAOs
+ *
+ * @author
+ *   Brian Schlining
+ * @since 2016-05-23T15:57:00
+ */
+object DevelopmentDAOFactory extends JPADAOFactory:
 
     private val config           = ConfigFactory.load()
     private val productName      =
@@ -46,12 +47,9 @@ object DevelopmentDAOFactory extends JPADAOFactory {
         "jakarta.persistence.schema-generation.database.action" -> "create"
     )
 
-    lazy val entityManagerFactory: EntityManagerFactory = {
+    lazy val entityManagerFactory: EntityManagerFactory =
         val driver   = config.getString("org.mbari.vars.annotation.database.development.driver")
         val url      = config.getString("org.mbari.vars.annotation.database.development.url")
         val user     = config.getString("org.mbari.vars.annotation.database.development.user")
         val password = config.getString("org.mbari.vars.annotation.database.development.password")
         EntityManagerFactories(url, user, password, driver, developmentProps)
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/EntityManagerFactories.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/EntityManagerFactories.scala
@@ -25,17 +25,17 @@ import org.mbari.annosaurus.etc.jdk.Logging.given
 
 import java.lang.System.Logger.Level
 
-/** https://stackoverflow.com/questions/4106078/dynamic-jpa-connection
-  *
-  * THis factory allows us to instantiate an javax.persistence.EntityManager from the basic
-  * parameters (url, driver, password, username). You can pass in a map of additional properties to
-  * customize the EntityManager.
-  *
-  * @author
-  *   Brian Schlining
-  * @since 2016-05-05T17:29:00
-  */
-object EntityManagerFactories {
+/**
+ * https://stackoverflow.com/questions/4106078/dynamic-jpa-connection
+ *
+ * THis factory allows us to instantiate an javax.persistence.EntityManager from the basic parameters (url, driver,
+ * password, username). You can pass in a map of additional properties to customize the EntityManager.
+ *
+ * @author
+ *   Brian Schlining
+ * @since 2016-05-05T17:29:00
+ */
+object EntityManagerFactories:
 
     private val log = System.getLogger(getClass.getName)
 
@@ -54,10 +54,10 @@ object EntityManagerFactories {
         "hibernate.type.java_time_use_direct_jdbc" -> "true"
     )
 
-    def apply(properties: Map[String, String]): EntityManagerFactory = {
+    def apply(properties: Map[String, String]): EntityManagerFactory =
         val props = PRODUCTION_PROPS ++ properties
         val emf   = Persistence.createEntityManagerFactory("annosaurus", props.asJava)
-        if (log.isLoggable(Level.INFO)) {
+        if log.isLoggable(Level.INFO) then
             val props = emf
                 .getProperties
                 .asScala
@@ -67,9 +67,7 @@ object EntityManagerFactories {
                 .sorted
                 .mkString("\n")
             log.atInfo.log(s"EntityManager Properties:\n${props}")
-        }
         emf
-    }
 
     def apply(
         url: String,
@@ -77,7 +75,7 @@ object EntityManagerFactories {
         password: String,
         driverName: String,
         properties: Map[String, String] = Map.empty
-    ): EntityManagerFactory = {
+    ): EntityManagerFactory =
 
         val map = Map(
             "jakarta.persistence.jdbc.url"      -> url,
@@ -86,9 +84,8 @@ object EntityManagerFactories {
             "jakarta.persistence.jdbc.driver"   -> driverName
         )
         apply(map ++ properties)
-    }
 
-    def apply(configNode: String): EntityManagerFactory = {
+    def apply(configNode: String): EntityManagerFactory =
         val driver   = config.getString(configNode + ".driver")
         val password = config.getString(configNode + ".password")
 //        val productName = config.getString(configNode + ".name")
@@ -103,6 +100,3 @@ object EntityManagerFactories {
             "jakarta.persistence.jdbc.user"     -> user
         )
         apply(props)
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/EntityManagerFactories.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/EntityManagerFactories.scala
@@ -19,11 +19,10 @@ package org.mbari.annosaurus.repository.jpa
 import com.typesafe.config.ConfigFactory
 import jakarta.persistence.{EntityManagerFactory, Persistence}
 import org.mbari.annosaurus.AppConfig
-
-import scala.jdk.CollectionConverters.*
 import org.mbari.annosaurus.etc.jdk.Logging.given
 
 import java.lang.System.Logger.Level
+import scala.jdk.CollectionConverters.*
 
 /**
  * https://stackoverflow.com/questions/4106078/dynamic-jpa-connection

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/EntityManagerFactories.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/EntityManagerFactories.scala
@@ -43,14 +43,14 @@ object EntityManagerFactories {
 
     // https://juliuskrah.com/tutorial/2017/02/16/getting-started-with-hikaricp-hibernate-and-jpa/
     val PRODUCTION_PROPS = Map(
-        "hibernate.connection.provider_class" -> "org.hibernate.hikaricp.internal.HikariCPConnectionProvider",
-        "hibernate.hbm2ddl.auto"              -> "validate",
-        "hibernate.hikari.idleTimeout"        -> "30000",
-        "hibernate.jdbc.batch_size"           -> "100",
-        "hibernate.hikari.maximumPoolSize"    -> s"${AppConfig.NumberOfVertxWorkers * 2}", // Same as vertx worker pool threads
-        "hibernate.hikari.minimumIdle"        -> "2",
-        "hibernate.order_inserts"             -> "true",
-        "hibernate.order_updates"             -> "true",
+        "hibernate.connection.provider_class"      -> "org.hibernate.hikaricp.internal.HikariCPConnectionProvider",
+        "hibernate.hbm2ddl.auto"                   -> "validate",
+        "hibernate.hikari.idleTimeout"             -> "30000",
+        "hibernate.jdbc.batch_size"                -> "100",
+        "hibernate.hikari.maximumPoolSize"         -> s"${AppConfig.NumberOfVertxWorkers * 2}", // Same as vertx worker pool threads
+        "hibernate.hikari.minimumIdle"             -> "2",
+        "hibernate.order_inserts"                  -> "true",
+        "hibernate.order_updates"                  -> "true",
         "hibernate.type.java_time_use_direct_jdbc" -> "true"
     )
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/EntityManagerFactories.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/EntityManagerFactories.scala
@@ -19,7 +19,7 @@ package org.mbari.annosaurus.repository.jpa
 import com.typesafe.config.ConfigFactory
 import jakarta.persistence.{EntityManagerFactory, Persistence}
 import org.mbari.annosaurus.AppConfig
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 
 import java.lang.System.Logger.Level
 import scala.jdk.CollectionConverters.*

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImageReferenceDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImageReferenceDAOImpl.scala
@@ -16,10 +16,11 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import java.net.URL
 import jakarta.persistence.EntityManager
 import org.mbari.annosaurus.repository.ImageReferenceDAO
 import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
+
+import java.net.URL
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImageReferenceDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImageReferenceDAOImpl.scala
@@ -21,13 +21,14 @@ import jakarta.persistence.EntityManager
 import org.mbari.annosaurus.repository.ImageReferenceDAO
 import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T17:17:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T17:17:00
+ */
 class ImageReferenceDAOImpl(entityManager: EntityManager)
     extends BaseDAO[ImageReferenceEntity](entityManager)
-    with ImageReferenceDAO[ImageReferenceEntity] {
+    with ImageReferenceDAO[ImageReferenceEntity]:
 
     override def newPersistentObject(): ImageReferenceEntity = new ImageReferenceEntity
 
@@ -37,7 +38,7 @@ class ImageReferenceDAOImpl(entityManager: EntityManager)
         heightPixels: Option[Int] = None,
         widthPixels: Option[Int] = None,
         format: Option[String] = None
-    ): ImageReferenceEntity = {
+    ): ImageReferenceEntity =
         val imageReference = newPersistentObject()
         imageReference.setUrl(url)
         description.foreach(imageReference.setDescription)
@@ -46,7 +47,6 @@ class ImageReferenceDAOImpl(entityManager: EntityManager)
         format.foreach(imageReference.setFormat)
 
         imageReference
-    }
 
     override def findAll(
         limit: Option[Int] = None,
@@ -59,5 +59,3 @@ class ImageReferenceDAOImpl(entityManager: EntityManager)
 
     override def findByImageName(name: String): Seq[ImageReferenceEntity] =
         findByNamedQuery("ImageReference.findByImageName", Map("name" -> s"%$name%"))
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOImpl.scala
@@ -26,7 +26,7 @@ import org.mbari.vcr4j.time.Timecode
 import java.sql.Timestamp
 import java.time.{Duration, Instant}
 import java.util.function.Function
-import java.util.{UUID, stream}
+import java.util.{stream, UUID}
 import scala.jdk.CollectionConverters.*
 
 /**

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOImpl.scala
@@ -28,6 +28,7 @@ import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
 import org.mbari.vcr4j.time.Timecode
 
 import scala.jdk.CollectionConverters._
+import org.hibernate.jpa.QueryHints
 
 /** @author
   *   Brian Schlining
@@ -144,6 +145,7 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
         val query          = entityManager.createNamedQuery("ImagedMoment.countBetweenUpdatedDates")
         val startTimestamp = Timestamp.from(start)
         val endTimestamp   = Timestamp.from(end)
+        query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, startTimestamp)
         query.setParameter(2, endTimestamp)
         query

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOImpl.scala
@@ -16,19 +16,18 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import java.sql.Timestamp
-import java.time.{Duration, Instant}
-import java.util.function.Function
-import java.util.{stream, UUID}
 import jakarta.persistence.EntityManager
-
+import org.hibernate.jpa.QueryHints
 import org.mbari.annosaurus.domain.{ImagedMoment, WindowRequest}
 import org.mbari.annosaurus.repository.ImagedMomentDAO
 import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
 import org.mbari.vcr4j.time.Timecode
 
+import java.sql.Timestamp
+import java.time.{Duration, Instant}
+import java.util.function.Function
+import java.util.{UUID, stream}
 import scala.jdk.CollectionConverters.*
-import org.hibernate.jpa.QueryHints
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOImpl.scala
@@ -27,16 +27,17 @@ import org.mbari.annosaurus.repository.ImagedMomentDAO
 import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
 import org.mbari.vcr4j.time.Timecode
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import org.hibernate.jpa.QueryHints
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T16:34:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T16:34:00
+ */
 class ImagedMomentDAOImpl(entityManager: EntityManager)
     extends BaseDAO[ImagedMomentEntity](entityManager)
-    with ImagedMomentDAO[ImagedMomentEntity] {
+    with ImagedMomentDAO[ImagedMomentEntity]:
 
     override def newPersistentObject(): ImagedMomentEntity = new ImagedMomentEntity
 
@@ -45,35 +46,31 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
         timecode: Option[Timecode] = None,
         elapsedTime: Option[Duration] = None,
         recordedDate: Option[Instant] = None
-    ): ImagedMomentEntity = {
+    ): ImagedMomentEntity =
         val imagedMoment = new ImagedMomentEntity
         imagedMoment.setVideoReferenceUuid(videoReferenceUUID)
         timecode.foreach(imagedMoment.setTimecode)
         elapsedTime.foreach(imagedMoment.setElapsedTime)
         recordedDate.foreach(imagedMoment.setRecordedTimestamp)
         imagedMoment
-    }
 
     override def newPersistentObject(imagedMoment: ImagedMomentEntity): ImagedMomentEntity =
         ImagedMoment.from(imagedMoment, true).toEntity
 
-    def deleteIfEmptyByUUID(uuid: UUID): Boolean = {
-        findByUUID(uuid).exists(imagedMoment => {
-
-            if (imagedMoment.getImageReferences.isEmpty && imagedMoment.getObservations.isEmpty) {
+    def deleteIfEmptyByUUID(uuid: UUID): Boolean =
+        findByUUID(uuid).exists(imagedMoment =>
+            if imagedMoment.getImageReferences.isEmpty && imagedMoment.getObservations.isEmpty then
                 delete(imagedMoment)
                 true
-            }
             else false
-        })
-    }
+        )
 
     override def findBetweenUpdatedDates(
         start: Instant,
         end: Instant,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    ): Iterable[ImagedMomentEntity] = {
+    ): Iterable[ImagedMomentEntity] =
 
         val startTimestamp = Timestamp.from(start)
         val endTimestamp   = Timestamp.from(end)
@@ -84,14 +81,13 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             limit,
             offset
         )
-    }
 
     override def streamBetweenUpdatedDates(
         start: Instant,
         end: Instant,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    ): java.util.stream.Stream[ImagedMomentEntity] = {
+    ): java.util.stream.Stream[ImagedMomentEntity] =
 
         val startTimestamp = Timestamp.from(start)
         val endTimestamp   = Timestamp.from(end)
@@ -102,7 +98,6 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             limit,
             offset
         )
-    }
 
     override def streamByVideoReferenceUUIDAndTimestamps(
         uuid: UUID,
@@ -110,22 +105,20 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
         endTimestamp: Instant,
         limit: Option[Int],
         offset: Option[Int]
-    ): java.util.stream.Stream[ImagedMomentEntity] = {
-
+    ): java.util.stream.Stream[ImagedMomentEntity] =
         streamByNamedQuery(
             "ImagedMoment.findByVideoReferenceUUIDAndTimestamps",
             Map("uuid" -> uuid, "start" -> startTimestamp, "end" -> endTimestamp),
             limit,
             offset
         )
-    }
 
     override def streamVideoReferenceUuidsBetweenUpdatedDates(
         start: Instant,
         end: Instant,
         limit: Option[Int],
         offset: Option[Int]
-    ): java.util.stream.Stream[UUID] = {
+    ): java.util.stream.Stream[UUID] =
         val query          =
             entityManager.createNamedQuery(
                 "ImagedMoment.findVideoReferenceUUIDsModifiedBetweenDates"
@@ -136,12 +129,12 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
         query.setParameter(2, endTimestamp)
         query
             .getResultStream
-            .map(new Function[Any, UUID] {
-                override def apply(t: Any): UUID = UUID.fromString(t.toString)
-            })
-    }
+            .map(
+                new Function[Any, UUID]:
+                    override def apply(t: Any): UUID = UUID.fromString(t.toString)
+            )
 
-    override def countBetweenUpdatedDates(start: Instant, end: Instant): Int = {
+    override def countBetweenUpdatedDates(start: Instant, end: Instant): Int =
         val query          = entityManager.createNamedQuery("ImagedMoment.countBetweenUpdatedDates")
         val startTimestamp = Timestamp.from(start)
         val endTimestamp   = Timestamp.from(end)
@@ -153,12 +146,11 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.toString().toInt)
             .head
-    }
 
     override def findAllVideoReferenceUUIDs(
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    ): Iterable[UUID] = {
+    ): Iterable[UUID] =
         val query = entityManager.createNamedQuery("ImagedMoment.findAllVideoReferenceUUIDs")
         limit.foreach(query.setMaxResults)
         offset.foreach(query.setFirstResult)
@@ -166,23 +158,21 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             .getResultList
             .asScala
             .map(s => UUID.fromString(s.toString))
-    }
 
-    override def countAllByVideoReferenceUuids(): Map[UUID, Int] = {
+    override def countAllByVideoReferenceUuids(): Map[UUID, Int] =
         val query = entityManager.createNamedQuery("ImagedMoment.countAllByVideoReferenceUUIDs")
         query
             .getResultList
             .asScala
             .map(_.asInstanceOf[Array[Object]])
-            .map(xs => {
+            .map(xs =>
                 val uuid  = UUID.fromString(xs(0).toString())
                 val count = xs(1).toString().toInt
                 uuid -> count
-            })
+            )
             .toMap
-    }
 
-    override def countByConcept(concept: String): Int = {
+    override def countByConcept(concept: String): Int =
         val query = entityManager.createNamedQuery("ImagedMoment.countByConcept")
         query.setParameter(1, concept)
         query
@@ -190,7 +180,6 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.toString().toInt)
             .head
-    }
 
     override def findByConcept(
         concept: String,
@@ -206,7 +195,7 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
     ): stream.Stream[ImagedMomentEntity] =
         streamByNamedQuery("ImagedMoment.findByConcept", Map("concept" -> concept), limit, offset)
 
-    override def countByConceptWithImages(concept: String): Int = {
+    override def countByConceptWithImages(concept: String): Int =
         val query = entityManager.createNamedQuery("ImagedMoment.countByConceptWithImages")
         query.setParameter(1, concept)
         query
@@ -214,9 +203,8 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.toString().toInt)
             .head
-    }
 
-    override def countModifiedBeforeDate(videoReferenceUuid: UUID, date: Instant): Int = {
+    override def countModifiedBeforeDate(videoReferenceUuid: UUID, date: Instant): Int =
         val query = entityManager.createNamedQuery("ImagedMoment.countModifiedBeforeDate")
         query.setParameter(1, videoReferenceUuid)
         query.setParameter(2, Timestamp.from(date))
@@ -225,7 +213,6 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.toString().toInt)
             .head
-    }
 
     override def findByConceptWithImages(
         concept: String,
@@ -239,7 +226,7 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             offset
         )
 
-    override def countByVideoReferenceUUID(uuid: UUID): Int = {
+    override def countByVideoReferenceUUID(uuid: UUID): Int =
         val query = entityManager.createNamedQuery("ImagedMoment.countByVideoReferenceUUID")
 //    if (DatabaseProductName.isPostgreSQL()) {
 //      query.setParameter(1, uuid)
@@ -253,9 +240,8 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.toString().toInt)
             .head
-    }
 
-    override def countByVideoReferenceUUIDWithImages(uuid: UUID): Int = {
+    override def countByVideoReferenceUUIDWithImages(uuid: UUID): Int =
         val query =
             entityManager.createNamedQuery("ImagedMoment.countByVideoReferenceUUIDWithImages")
         setUuidParameter(query, 1, uuid)
@@ -264,7 +250,6 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.toString().toInt)
             .head
-    }
 
     override def findByVideoReferenceUUID(
         uuid: UUID,
@@ -306,12 +291,11 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
         windowRequest: WindowRequest,
         limit: Option[Int] = None,
         offset: Option[Int] = None
-    ): Iterable[ImagedMomentEntity] = {
-
-        findByUUID(windowRequest.imagedMomentUuid) match {
+    ): Iterable[ImagedMomentEntity] =
+        findByUUID(windowRequest.imagedMomentUuid) match
             case None     => Nil
             case Some(im) =>
-                Option(im.getRecordedTimestamp) match {
+                Option(im.getRecordedTimestamp) match
                     case None               => Nil
                     case Some(recordedDate) =>
                         val start = recordedDate.minus(windowRequest.window)
@@ -326,10 +310,6 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
                             limit,
                             offset
                         )
-                }
-        }
-
-    }
 
     override def findAll(
         limit: Option[Int] = None,
@@ -373,7 +353,7 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
 
     override def countByLinkName(
         linkName: String
-    ): Int = {
+    ): Int =
         val query = entityManager.createNamedQuery("ImagedMoment.countByLinkName")
 
         query.setParameter(1, linkName)
@@ -383,7 +363,6 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.toString().toInt)
             .head
-    }
 
     override def findByVideoReferenceUUIDAndElapsedTime(
         uuid: UUID,
@@ -418,21 +397,21 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
     override def updateRecordedTimestampByObservationUuid(
         observationUuid: UUID,
         recordedTimestamp: Instant
-    ): Boolean = {
+    ): Boolean =
         val query =
             entityManager.createNamedQuery("ImagedMoment.updateRecordedTimestampByObservationUuid")
         query.setParameter(1, recordedTimestamp)
         query.setParameter(2, observationUuid)
         query.executeUpdate() > 0
-    }
 
-    /** A bulk delete operation. This will delete all annotation related data for a single video.
-      * (which is identified via its uuid (e.g. videoReferenceUUID)
-      *
-      * @param uuid
-      *   The UUID of the VideoReference. WARNING!! All annotation data associated to this
-      *   videoReference will be deleted.
-      */
+    /**
+     * A bulk delete operation. This will delete all annotation related data for a single video. (which is identified
+     * via its uuid (e.g. videoReferenceUUID)
+     *
+     * @param uuid
+     *   The UUID of the VideoReference. WARNING!! All annotation data associated to this videoReference will be
+     *   deleted.
+     */
     override def deleteByVideoReferenceUUUID(uuid: UUID): Int =
         val xs = findByVideoReferenceUUID(uuid)
         xs.foreach(delete)
@@ -441,14 +420,13 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
     override def moveToVideoReference(
         newVideoReferenceUuid: UUID,
         imageMomentUuids: Seq[UUID]
-    ): Int = {
-        if (imageMomentUuids.isEmpty) return 0
+    ): Int =
+        if imageMomentUuids.isEmpty then return 0
 
         val query = entityManager.createNamedQuery("ImagedMoment.moveToVideoReference")
         query.setParameter(1, newVideoReferenceUuid)
         query.setParameter(2, imageMomentUuids.asJava)
         query.executeUpdate()
-    }
 
 //  override def delete(entity: ImagedMomentImpl): Unit = {
 //    Option(entity.ancillaryDatum).foreach(entityManager.remove)
@@ -457,4 +435,3 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
 //    entity.imageReferences.foreach(entityManager.remove)
 //    entityManager.remove(entity)
 //  }
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/Implicits.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/Implicits.scala
@@ -20,33 +20,25 @@ import jakarta.persistence.EntityManager
 
 import scala.concurrent.{ExecutionContext, Future}
 
-/** Implicits used in this package
-  *
-  * @author
-  *   Brian Schlining
-  * @since 2016-05-06T13:34:00
-  */
-object Implicits {
+/**
+ * Implicits used in this package
+ *
+ * @author
+ *   Brian Schlining
+ * @since 2016-05-06T13:34:00
+ */
+object Implicits:
 
     // private[this] val log = LoggerFactory.getLogger(getClass)
 
-    implicit class RichEntityManager(entityManager: EntityManager) {
-        def runTransaction[R](fn: EntityManager => R)(implicit ec: ExecutionContext): Future[R] = {
+    implicit class RichEntityManager(entityManager: EntityManager):
+        def runTransaction[R](fn: EntityManager => R)(implicit ec: ExecutionContext): Future[R] =
             Future {
                 val transaction = entityManager.getTransaction
                 transaction.begin()
-                try {
+                try
                     val n = fn.apply(entityManager)
                     transaction.commit()
                     n
-                }
-                finally {
-                    if (transaction.isActive) {
-                        transaction.rollback()
-                    }
-                }
+                finally if transaction.isActive then transaction.rollback()
             }
-        }
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/IndexDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/IndexDAOImpl.scala
@@ -16,12 +16,11 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import java.util.UUID
 import jakarta.persistence.EntityManager
-
 import org.mbari.annosaurus.repository.IndexDAO
 import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
-import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
+
+import java.util.UUID
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/IndexDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/IndexDAOImpl.scala
@@ -23,13 +23,12 @@ import org.mbari.annosaurus.repository.IndexDAO
 import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
 import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
 
-/** @author
-  *   Brian Schlining
-  * @since 2019-02-08T08:55:00
-  */
-class IndexDAOImpl(entityManager: EntityManager)
-    extends BaseDAO[IndexEntity](entityManager)
-    with IndexDAO[IndexEntity] {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2019-02-08T08:55:00
+ */
+class IndexDAOImpl(entityManager: EntityManager) extends BaseDAO[IndexEntity](entityManager) with IndexDAO[IndexEntity]:
 
     def newPersistentObject(): IndexEntity = new IndexEntity
 
@@ -58,4 +57,3 @@ class IndexDAOImpl(entityManager: EntityManager)
     override def create(entity: IndexEntity): Unit = ???
 
     override def delete(entity: IndexEntity): Unit = ???
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/JPADAOFactory.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/JPADAOFactory.scala
@@ -16,19 +16,8 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import com.typesafe.config.ConfigFactory
 import jakarta.persistence.{EntityManager, EntityManagerFactory}
-import org.mbari.annosaurus.repository.{
-    AssociationDAO,
-    CachedAncillaryDatumDAO,
-    CachedVideoReferenceInfoDAO,
-    DAO,
-    ImageReferenceDAO,
-    ImagedMomentDAO,
-    IndexDAO,
-    ObservationDAO
-}
-import org.mbari.annosaurus.repository.jpa.entity.*
+import org.mbari.annosaurus.repository.DAO
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/JPADAOFactory.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/JPADAOFactory.scala
@@ -30,11 +30,12 @@ import org.mbari.annosaurus.repository.{
 }
 import org.mbari.annosaurus.repository.jpa.entity.*
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-25T17:27:00
-  */
-trait JPADAOFactory {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-25T17:27:00
+ */
+trait JPADAOFactory:
 
     def entityManagerFactory: EntityManagerFactory
 
@@ -87,12 +88,8 @@ trait JPADAOFactory {
     def newImagedMomentDAO(dao: DAO[?]): ImagedMomentDAOImpl =
         new ImagedMomentDAOImpl(extractEntityManager(dao))
 
-}
-
-object JPADAOFactory extends JPADAOFactory {
+object JPADAOFactory extends JPADAOFactory:
 
     lazy val entityManagerFactory = EntityManagerFactories("database")
-
-}
 
 class JPADAOFactoryImpl(val entityManagerFactory: EntityManagerFactory) extends JPADAOFactory

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOImpl.scala
@@ -17,18 +17,16 @@
 package org.mbari.annosaurus.repository.jpa
 
 import jakarta.persistence.EntityManager
+import org.hibernate.jpa.QueryHints
 import org.mbari.annosaurus.domain.{ConcurrentRequest, MultiRequest}
 import org.mbari.annosaurus.repository.ObservationDAO
+import org.mbari.annosaurus.repository.jdbc.*
 import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
 
-import java.sql.Timestamp
 import java.time.{Duration, Instant}
-import java.util.{stream, UUID}
+import java.util as ju
+import java.util.{UUID, stream}
 import scala.jdk.CollectionConverters.*
-import java.{util as ju}
-import org.mbari.annosaurus.repository.jdbc.*
-import jakarta.persistence.QueryHint
-import org.hibernate.jpa.QueryHints
 
 /**
  * @author

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOImpl.scala
@@ -165,7 +165,8 @@ class ObservationDAOImpl(entityManager: EntityManager)
     override def findAllConcepts(): Seq[String] =
         val query = entityManager.createNamedQuery("Observation.findAllNames")
         query.setHint(QueryHints.HINT_READONLY, true)
-        query.getResultList
+        query
+            .getResultList
             .asScala
             .filter(_ != null)
             .map(_.toString)
@@ -174,7 +175,8 @@ class ObservationDAOImpl(entityManager: EntityManager)
     override def findAllGroups(): Seq[String] =
         val query = entityManager.createNamedQuery("Observation.findAllGroups")
         query.setHint(QueryHints.HINT_READONLY, true)
-        query.getResultList
+        query
+            .getResultList
             .asScala
             .filter(_ != null)
             .map(_.toString)
@@ -183,7 +185,8 @@ class ObservationDAOImpl(entityManager: EntityManager)
     override def findAllActivities(): Seq[String] =
         val query = entityManager.createNamedQuery("Observation.findAllActivities")
         query.setHint(QueryHints.HINT_READONLY, true)
-        query.getResultList
+        query
+            .getResultList
             .asScala
             .filter(_ != null)
             .map(_.toString)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOImpl.scala
@@ -27,6 +27,8 @@ import java.util.{stream, UUID}
 import scala.jdk.CollectionConverters._
 import java.{util => ju}
 import org.mbari.annosaurus.repository.jdbc.*
+import jakarta.persistence.QueryHint
+import org.hibernate.jpa.QueryHints
 
 /** @author
   *   Brian Schlining
@@ -152,6 +154,7 @@ class ObservationDAOImpl(entityManager: EntityManager)
 
     override def countByMultiRequest(request: MultiRequest): Long = {
         val query = entityManager.createNamedQuery("Observation.countByMultiRequest")
+        query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter("uuids", request.videoReferenceUuids.asJava)
         query.getSingleResult.asInstanceOf[Number].longValue()
     }
@@ -160,27 +163,27 @@ class ObservationDAOImpl(entityManager: EntityManager)
       *   Order sequence of all concept names used
       */
     override def findAllConcepts(): Seq[String] =
-        entityManager
-            .createNamedQuery("Observation.findAllNames")
-            .getResultList
+        val query = entityManager.createNamedQuery("Observation.findAllNames")
+        query.setHint(QueryHints.HINT_READONLY, true)
+        query.getResultList
             .asScala
             .filter(_ != null)
             .map(_.toString)
             .toSeq
 
     override def findAllGroups(): Seq[String] =
-        entityManager
-            .createNamedQuery("Observation.findAllGroups")
-            .getResultList
+        val query = entityManager.createNamedQuery("Observation.findAllGroups")
+        query.setHint(QueryHints.HINT_READONLY, true)
+        query.getResultList
             .asScala
             .filter(_ != null)
             .map(_.toString)
             .toSeq
 
     override def findAllActivities(): Seq[String] =
-        entityManager
-            .createNamedQuery("Observation.findAllActivities")
-            .getResultList
+        val query = entityManager.createNamedQuery("Observation.findAllActivities")
+        query.setHint(QueryHints.HINT_READONLY, true)
+        query.getResultList
             .asScala
             .filter(_ != null)
             .map(_.toString)
@@ -204,6 +207,7 @@ class ObservationDAOImpl(entityManager: EntityManager)
 
     override def countByConcept(name: String): Int = {
         val query = entityManager.createNamedQuery("Observation.countByConcept")
+        query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, name)
         query
             .getResultList
@@ -214,6 +218,7 @@ class ObservationDAOImpl(entityManager: EntityManager)
 
     override def countByConceptWithImages(name: String): Int = {
         val query = entityManager.createNamedQuery("Observation.countByConceptWithImages")
+        query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, name)
         query
             .getResultList
@@ -224,6 +229,7 @@ class ObservationDAOImpl(entityManager: EntityManager)
 
     override def countByVideoReferenceUUID(uuid: UUID): Int = {
         val query = entityManager.createNamedQuery("Observation.countByVideoReferenceUUID")
+        query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, uuid)
         query
             .getResultList
@@ -234,6 +240,7 @@ class ObservationDAOImpl(entityManager: EntityManager)
 
     override def countAllByVideoReferenceUuids(): Map[UUID, Int] = {
         val query = entityManager.createNamedQuery("Observation.countAllByVideoReferenceUUIDs")
+        query.setHint(QueryHints.HINT_READONLY, true)
         query
             .getResultList
             .asScala

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOImpl.scala
@@ -24,19 +24,20 @@ import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
 import java.sql.Timestamp
 import java.time.{Duration, Instant}
 import java.util.{stream, UUID}
-import scala.jdk.CollectionConverters._
-import java.{util => ju}
+import scala.jdk.CollectionConverters.*
+import java.{util as ju}
 import org.mbari.annosaurus.repository.jdbc.*
 import jakarta.persistence.QueryHint
 import org.hibernate.jpa.QueryHints
 
-/** @author
-  *   Brian Schlining
-  * @since 2016-06-17T17:10:00
-  */
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-17T17:10:00
+ */
 class ObservationDAOImpl(entityManager: EntityManager)
     extends BaseDAO[ObservationEntity](entityManager)
-    with ObservationDAO[ObservationEntity] {
+    with ObservationDAO[ObservationEntity]:
 
     override def newPersistentObject(): ObservationEntity = new ObservationEntity
 
@@ -46,7 +47,7 @@ class ObservationDAOImpl(entityManager: EntityManager)
         observationDate: Instant = Instant.now(),
         group: Option[String] = None,
         duration: Option[Duration] = None
-    ): ObservationEntity = {
+    ): ObservationEntity =
 
         val observation = new ObservationEntity
         observation.setConcept(concept)
@@ -55,7 +56,6 @@ class ObservationDAOImpl(entityManager: EntityManager)
         group.foreach(observation.setGroup)
         duration.foreach(observation.setDuration)
         observation
-    }
 
     override def findByVideoReferenceUuid(
         uuid: UUID,
@@ -82,21 +82,19 @@ class ObservationDAOImpl(entityManager: EntityManager)
         endTimestamp: Instant,
         limit: Option[Int],
         offset: Option[Int]
-    ): stream.Stream[ObservationEntity] = {
-
+    ): stream.Stream[ObservationEntity] =
         streamByNamedQuery(
             "Observation.findByVideoReferenceUUIDAndTimestamps",
             Map("uuid" -> uuid, "start" -> startTimestamp, "end" -> endTimestamp),
             limit,
             offset
         )
-    }
 
     override def countByVideoReferenceUUIDAndTimestamps(
         uuid: UUID,
         startTimestamp: Instant,
         endTimestamp: Instant
-    ): Int = {
+    ): Int =
         // val query =
         //     entityManager.createNamedQuery("Observation.countByVideoReferenceUUIDAndTimestamps")
         // // setUuidParameter(query, 1, uuid)
@@ -112,13 +110,12 @@ class ObservationDAOImpl(entityManager: EntityManager)
         query.setParameter("start", startTimestamp)
         query.setParameter("end", endTimestamp)
         query.getSingleResult.asInstanceOf[Number].intValue()
-    }
 
     override def streamByConcurrentRequest(
         request: ConcurrentRequest,
         limit: Option[Int],
         offset: Option[Int]
-    ): stream.Stream[ObservationEntity] = {
+    ): stream.Stream[ObservationEntity] =
         streamByNamedQuery(
             "Observation.findByConcurrentRequest",
             Map(
@@ -129,39 +126,36 @@ class ObservationDAOImpl(entityManager: EntityManager)
             limit,
             offset
         )
-    }
 
-    override def countByConcurrentRequest(request: ConcurrentRequest): Long = {
+    override def countByConcurrentRequest(request: ConcurrentRequest): Long =
         val query = entityManager.createNamedQuery("Observation.countByConcurrentRequest")
         query.setParameter("uuids", request.videoReferenceUuids.asJava)
         query.setParameter("start", request.startTimestamp)
         query.setParameter("end", request.endTimestamp)
         query.getSingleResult.asInstanceOf[Number].longValue()
-    }
 
     override def streamByMultiRequest(
         request: MultiRequest,
         limit: Option[Int],
         offset: Option[Int]
-    ): stream.Stream[ObservationEntity] = {
+    ): stream.Stream[ObservationEntity] =
         streamByNamedQuery(
             "Observation.findByMultiRequest",
             Map("uuids" -> request.videoReferenceUuids),
             limit,
             offset
         )
-    }
 
-    override def countByMultiRequest(request: MultiRequest): Long = {
+    override def countByMultiRequest(request: MultiRequest): Long =
         val query = entityManager.createNamedQuery("Observation.countByMultiRequest")
         query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter("uuids", request.videoReferenceUuids.asJava)
         query.getSingleResult.asInstanceOf[Number].longValue()
-    }
 
-    /** @return
-      *   Order sequence of all concept names used
-      */
+    /**
+     * @return
+     *   Order sequence of all concept names used
+     */
     override def findAllConcepts(): Seq[String] =
         val query = entityManager.createNamedQuery("Observation.findAllNames")
         query.setHint(QueryHints.HINT_READONLY, true)
@@ -198,7 +192,7 @@ class ObservationDAOImpl(entityManager: EntityManager)
     ): Iterable[ObservationEntity] =
         findByNamedQuery("Observation.findAll", limit = limit, offset = offset)
 
-    override def findAllConceptsByVideoReferenceUUID(uuid: UUID): Seq[String] = {
+    override def findAllConceptsByVideoReferenceUUID(uuid: UUID): Seq[String] =
         val query = entityManager.createNamedQuery("Observation.findAllNamesByVideoReferenceUUID")
         query.setParameter(1, uuid)
         query
@@ -206,9 +200,8 @@ class ObservationDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.toString)
             .toSeq
-    }
 
-    override def countByConcept(name: String): Int = {
+    override def countByConcept(name: String): Int =
         val query = entityManager.createNamedQuery("Observation.countByConcept")
         query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, name)
@@ -217,9 +210,8 @@ class ObservationDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.asInstanceOf[Number].intValue())
             .head
-    }
 
-    override def countByConceptWithImages(name: String): Int = {
+    override def countByConceptWithImages(name: String): Int =
         val query = entityManager.createNamedQuery("Observation.countByConceptWithImages")
         query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, name)
@@ -228,9 +220,8 @@ class ObservationDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.asInstanceOf[Number].intValue())
             .head
-    }
 
-    override def countByVideoReferenceUUID(uuid: UUID): Int = {
+    override def countByVideoReferenceUUID(uuid: UUID): Int =
         val query = entityManager.createNamedQuery("Observation.countByVideoReferenceUUID")
         query.setHint(QueryHints.HINT_READONLY, true)
         query.setParameter(1, uuid)
@@ -239,36 +230,30 @@ class ObservationDAOImpl(entityManager: EntityManager)
             .asScala
             .map(_.asInstanceOf[Number].intValue())
             .head
-    }
 
-    override def countAllByVideoReferenceUuids(): Map[UUID, Int] = {
+    override def countAllByVideoReferenceUuids(): Map[UUID, Int] =
         val query = entityManager.createNamedQuery("Observation.countAllByVideoReferenceUUIDs")
         query.setHint(QueryHints.HINT_READONLY, true)
         query
             .getResultList
             .asScala
             .map(_.asInstanceOf[Array[Object]])
-            .map(xs => {
+            .map(xs =>
                 val uuid  = xs(0).asUUID.getOrElse(throw new RuntimeException("UUID is null"))
                 val count = xs(1).asInt.getOrElse(0)
                 uuid -> count
-            })
+            )
             .toMap
-    }
 
-    override def updateConcept(oldConcept: String, newConcept: String): Int = {
+    override def updateConcept(oldConcept: String, newConcept: String): Int =
         val query = entityManager.createNamedQuery("Observation.updateConcept")
         query.setParameter(1, newConcept)
         query.setParameter(2, oldConcept)
         query.executeUpdate()
-    }
 
-    override def changeImageMoment(imagedMomentUuid: UUID, observationUuid: UUID): Int = {
+    override def changeImageMoment(imagedMomentUuid: UUID, observationUuid: UUID): Int =
         val query = entityManager.createNamedQuery("Observation.updateImagedMomentUUID")
         query
             .setParameter(1, imagedMomentUuid)
             .setParameter(2, observationUuid)
         query.executeUpdate()
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOImpl.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOImpl.scala
@@ -25,7 +25,7 @@ import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
 
 import java.time.{Duration, Instant}
 import java.util as ju
-import java.util.{UUID, stream}
+import java.util.{stream, UUID}
 import scala.jdk.CollectionConverters.*
 
 /**

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/entity/extensions.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/entity/extensions.scala
@@ -19,10 +19,8 @@ package org.mbari.annosaurus.repository.jpa.entity
 import java.time.Instant
 import java.util.UUID
 
-object extensions {
+object extensions:
 
     extension (po: IPersistentObject)
         def primaryKey: Option[UUID]     = Option(po.getUuid)
         def lastUpdated: Option[Instant] = Option(po.getLastUpdatedTime).map(_.toInstant)
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/extensions.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/extensions.scala
@@ -17,9 +17,9 @@
 package org.mbari.annosaurus.repository.jpa
 
 import jakarta.persistence.EntityManager
+import org.mbari.annosaurus.etc.jdk.Logging.given
 
 import scala.concurrent.{ExecutionContext, Future}
-import org.mbari.annosaurus.etc.jdk.Logging.given
 import scala.util.control.NonFatal
 
 /**

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/extensions.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/extensions.scala
@@ -22,12 +22,13 @@ import scala.concurrent.{ExecutionContext, Future}
 import org.mbari.annosaurus.etc.jdk.Logging.given
 import scala.util.control.NonFatal
 
-/** Implicits used in this package
-  *
-  * @author
-  *   Brian Schlining
-  * @since 2016-05-06T13:34:00
-  */
+/**
+ * Implicits used in this package
+ *
+ * @author
+ *   Brian Schlining
+ * @since 2016-05-06T13:34:00
+ */
 object extensions:
 
     private val log = System.getLogger(getClass.getName)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/extensions.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/extensions.scala
@@ -17,7 +17,7 @@
 package org.mbari.annosaurus.repository.jpa
 
 import jakarta.persistence.EntityManager
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/jpa.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/jpa/jpa.scala
@@ -16,12 +16,13 @@
 
 package org.mbari.annosaurus.repository
 
-/** This package contains the JPA implementation of the data model and DAOs. If needed, an alternate
-  * implementation could be created for a particular NoSQL database. We feel that SQL databases will
-  * be the most commonly used data store, so we wrote a JPA implentation first.
-  *
-  * @author
-  *   Brian Schlining
-  * @since 2016-06-25T17:19:00
-  */
+/**
+ * This package contains the JPA implementation of the data model and DAOs. If needed, an alternate implementation could
+ * be created for a particular NoSQL database. We feel that SQL databases will be the most commonly used data store, so
+ * we wrote a JPA implentation first.
+ *
+ * @author
+ *   Brian Schlining
+ * @since 2016-06-25T17:19:00
+ */
 package object jpa {}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/JDBC.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/JDBC.scala
@@ -43,14 +43,9 @@ object JDBC:
                 columnClassName = metadata.getColumnClassName(i)
             yield JDBC.Metadata(columnName, columnType, columnSize, columnLabel, columnClassName)
 
-class JDBC(user: String, password: String, url: String, driver: String):
+class JDBC(config: DatabaseConfig):
 
-    Class.forName(driver)
-
-    def this(config: DatabaseConfig) = this(config.user, config.password, config.url, config.driver)
-
-    def newConnection(): Connection =
-        java.sql.DriverManager.getConnection(url, user, password)
+    def newConnection(): Connection = config.newConnection()
 
     def runQuery[T](
         sql: String,

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/JDBC.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/JDBC.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.repository.query
+
+import org.mbari.annosaurus.DatabaseConfig
+
+import java.sql.{Connection, PreparedStatement, ResultSet}
+import scala.collection.mutable.ListBuffer
+import scala.util.Using
+
+object JDBC {
+    case class Metadata(columnName: String,
+                        columnType: String,
+                        columnSize: Int,
+                        columnLabel: String,
+                        columnClassName: String)
+    object Metadata {
+        def fromResultSet(rs: ResultSet): Seq[Metadata] = {
+            val metadata = rs.getMetaData
+            val n = metadata.getColumnCount
+            for
+                i <- 1 to n
+                columnName = metadata.getColumnName(i)
+                columnType = metadata.getColumnTypeName(i)
+                columnSize = metadata.getColumnDisplaySize(i)
+                columnLabel = metadata.getColumnLabel(i)
+                columnClassName = metadata.getColumnClassName(i)
+            yield {
+                JDBC.Metadata(columnName, columnType, columnSize, columnLabel, columnClassName)
+            }
+        }
+    }
+}
+
+
+class JDBC(user: String, password: String, url: String, driver: String) {
+
+    def this(config: DatabaseConfig) = this(config.user, config.password, config.url, config.driver)
+
+    def newConnection(): Connection = {
+        Class.forName(driver)
+        java.sql.DriverManager.getConnection(url, user, password)
+    }
+
+    def runQuery[T](sql: String, f: ResultSet => T): Either[Throwable, T] = {
+        Using.Manager(use =>
+            val conn = use(newConnection())
+            conn.setReadOnly(true)
+            val stmt = use(conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))
+            val rs = use(stmt.executeQuery(sql))
+            f(rs)
+        ).toEither
+    }
+
+    def runPreparedStatement(statement: PreparedStatement, f: ResultSet => Unit): Either[Throwable, Unit] = {
+        Using.Manager(use =>
+            val rs = use(statement.executeQuery())
+            f(rs)
+        ).toEither
+    }
+
+    def listColumnsMetadata(viewName: String): Either[Throwable, Seq[JDBC.Metadata]] = {
+        val sql = s"SELECT * FROM $viewName LIMIT 1"
+        runQuery(sql, rs => JDBC.Metadata.fromResultSet(rs))
+    }
+
+    def findDistinct[A](viewName: String, columName: String, transform: Object => Option[A]): Either[Throwable, Seq[A]] =
+        val sql = s"SELECT DISTINCT $columName FROM $viewName"
+        runQuery(sql, rs => {
+            val values = ListBuffer.newBuilder[A]
+            while (rs.next()) {
+                transform(rs.getObject(columName)) match
+                    case Some(value) => values += value
+                    case None        => ()
+            }
+            values.result().toSeq
+        })
+
+    def countDistinct(viewName: String, columnName: String): Either[Throwable, Int] = {
+        val sql = s"SELECT COUNT(DISTINCT $columnName) FROM $viewName"
+        runQuery(sql, rs => {
+            rs.next()
+            rs.getInt(1)
+        })
+    }
+
+    def findMinMax[A](viewName: String, columnName: String, transform: Object => Option[A]): Either[Throwable, Option[(A, A)]] = {
+        val sql = s"SELECT MIN($columnName), MAX($columnName) FROM $viewName WHERE $columnName IS NOT NULL"
+        runQuery(sql, rs => {
+            rs.next()
+            val minOpt = transform(rs.getObject(1))
+            val maxOpt = transform(rs.getObject(2))
+            for {
+                min <- minOpt
+                max <- maxOpt
+            } yield (min, max)
+        })
+    }
+}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/JDBC.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/JDBC.scala
@@ -49,10 +49,11 @@ object JDBC {
 
 class JDBC(user: String, password: String, url: String, driver: String) {
 
+    Class.forName(driver)
+
     def this(config: DatabaseConfig) = this(config.user, config.password, config.url, config.driver)
 
     def newConnection(): Connection = {
-        Class.forName(driver)
         java.sql.DriverManager.getConnection(url, user, password)
     }
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/JDBC.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/JDBC.scala
@@ -23,21 +23,23 @@ import scala.collection.mutable.ListBuffer
 import scala.util.Using
 
 object JDBC {
-    case class Metadata(columnName: String,
-                        columnType: String,
-                        columnSize: Int,
-                        columnLabel: String,
-                        columnClassName: String)
+    case class Metadata(
+        columnName: String,
+        columnType: String,
+        columnSize: Int,
+        columnLabel: String,
+        columnClassName: String
+    )
     object Metadata {
         def fromResultSet(rs: ResultSet): Seq[Metadata] = {
             val metadata = rs.getMetaData
-            val n = metadata.getColumnCount
+            val n        = metadata.getColumnCount
             for
-                i <- 1 to n
-                columnName = metadata.getColumnName(i)
-                columnType = metadata.getColumnTypeName(i)
-                columnSize = metadata.getColumnDisplaySize(i)
-                columnLabel = metadata.getColumnLabel(i)
+                i              <- 1 to n
+                columnName      = metadata.getColumnName(i)
+                columnType      = metadata.getColumnTypeName(i)
+                columnSize      = metadata.getColumnDisplaySize(i)
+                columnLabel     = metadata.getColumnLabel(i)
                 columnClassName = metadata.getColumnClassName(i)
             yield {
                 JDBC.Metadata(columnName, columnType, columnSize, columnLabel, columnClassName)
@@ -45,7 +47,6 @@ object JDBC {
         }
     }
 }
-
 
 class JDBC(user: String, password: String, url: String, driver: String) {
 
@@ -57,58 +58,92 @@ class JDBC(user: String, password: String, url: String, driver: String) {
         java.sql.DriverManager.getConnection(url, user, password)
     }
 
-    def runQuery[T](sql: String, f: ResultSet => T): Either[Throwable, T] = {
-        Using.Manager(use =>
-            val conn = use(newConnection())
-            conn.setReadOnly(true)
-            val stmt = use(conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))
-            val rs = use(stmt.executeQuery(sql))
-            f(rs)
-        ).toEither
+    def runQuery[T](
+        sql: String,
+        f: ResultSet => T,
+        limit: Option[Int] = None,
+        offset: Option[Int] = None
+    ): Either[Throwable, T] = {
+        Using
+            .Manager(use =>
+                val conn = use(newConnection())
+                conn.setReadOnly(true)
+                val stmt = use(
+                    conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
+                )
+                limit.foreach(stmt.setMaxRows)
+                offset.foreach(stmt.setFetchSize)
+                val rs   = use(stmt.executeQuery(sql))
+                f(rs)
+            )
+            .toEither
     }
 
-    def runPreparedStatement(statement: PreparedStatement, f: ResultSet => Unit): Either[Throwable, Unit] = {
-        Using.Manager(use =>
-            val rs = use(statement.executeQuery())
-            f(rs)
-        ).toEither
+    def runPreparedStatement(
+        statement: PreparedStatement,
+        f: ResultSet => Unit
+    ): Either[Throwable, Unit] = {
+        Using
+            .Manager(use =>
+                val rs = use(statement.executeQuery())
+                f(rs)
+            )
+            .toEither
     }
 
     def listColumnsMetadata(viewName: String): Either[Throwable, Seq[JDBC.Metadata]] = {
-        val sql = s"SELECT * FROM $viewName LIMIT 1"
-        runQuery(sql, rs => JDBC.Metadata.fromResultSet(rs))
+        val sql = s"SELECT * FROM $viewName"
+        runQuery(sql, rs => JDBC.Metadata.fromResultSet(rs), limit = Some(1))
     }
 
-    def findDistinct[A](viewName: String, columName: String, transform: Object => Option[A]): Either[Throwable, Seq[A]] =
-        val sql = s"SELECT DISTINCT $columName FROM $viewName"
-        runQuery(sql, rs => {
-            val values = ListBuffer.newBuilder[A]
-            while (rs.next()) {
-                transform(rs.getObject(columName)) match
-                    case Some(value) => values += value
-                    case None        => ()
+    def findDistinct[A](
+        viewName: String,
+        columName: String,
+        transform: Object => Option[A]
+    ): Either[Throwable, Seq[A]] =
+        val sql = s"SELECT DISTINCT $columName FROM $viewName ORDER BY $columName ASC"
+        runQuery(
+            sql,
+            rs => {
+                val values = ListBuffer.newBuilder[A]
+                while (rs.next()) {
+                    transform(rs.getObject(columName)) match
+                        case Some(value) => values += value
+                        case None        => ()
+                }
+                values.result().toSeq
             }
-            values.result().toSeq
-        })
+        )
 
     def countDistinct(viewName: String, columnName: String): Either[Throwable, Int] = {
         val sql = s"SELECT COUNT(DISTINCT $columnName) FROM $viewName"
-        runQuery(sql, rs => {
-            rs.next()
-            rs.getInt(1)
-        })
+        runQuery(
+            sql,
+            rs => {
+                rs.next()
+                rs.getInt(1)
+            }
+        )
     }
 
-    def findMinMax[A](viewName: String, columnName: String, transform: Object => Option[A]): Either[Throwable, Option[(A, A)]] = {
-        val sql = s"SELECT MIN($columnName), MAX($columnName) FROM $viewName WHERE $columnName IS NOT NULL"
-        runQuery(sql, rs => {
-            rs.next()
-            val minOpt = transform(rs.getObject(1))
-            val maxOpt = transform(rs.getObject(2))
-            for {
-                min <- minOpt
-                max <- maxOpt
-            } yield (min, max)
-        })
+    def findMinMax[A](
+        viewName: String,
+        columnName: String,
+        transform: Object => Option[A]
+    ): Either[Throwable, Option[(A, A)]] = {
+        val sql =
+            s"SELECT MIN($columnName), MAX($columnName) FROM $viewName WHERE $columnName IS NOT NULL"
+        runQuery(
+            sql,
+            rs => {
+                rs.next()
+                val minOpt = transform(rs.getObject(1))
+                val maxOpt = transform(rs.getObject(2))
+                for {
+                    min <- minOpt
+                    max <- maxOpt
+                } yield (min, max)
+            }
+        )
     }
 }

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
@@ -16,7 +16,7 @@
 
 package org.mbari.annosaurus.repository.query
 
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+import org.mbari.annosaurus.etc.jdk.Loggers.{*, given}
 
 import java.sql.PreparedStatement
 import scala.util.Try
@@ -55,7 +55,7 @@ object PreparedStatementGenerator:
         val select   = buildSelectClause(query)
         val where    = buildWhereClause(tableName, query)
         val distinct = if query.distinct then "DISTINCT" else ""
-        val orderBy  = query.orderby match
+        val orderBy  = query.orderBy match
             case Some(columns) => columns.mkString(", ")
             case None          =>
                 if query.strict then query.select.head

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
@@ -83,7 +83,7 @@ object PreparedStatementGenerator:
         tableName: String,
         query: Query
     ): String =
-        if (query.where.isEmpty) ""
+        if query.where.isEmpty then ""
         else
             val wheres = query.where.map(_.toPreparedStatementTemplate).mkString(" AND ")
             if query.concurrentObservations && query.relatedAssociations then s"""WHERE $ObservationUuid IN (

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.repository.query
+
+import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+
+import java.sql.PreparedStatement
+import scala.util.Try
+object PreparedStatementGenerator {
+
+    val ObservationUuid = "observation_uuid"
+    val ImagedMomentUuid = "imaged_moment_uuid"
+
+    private val log = System.getLogger(getClass.getName)
+
+    def bind(statement: PreparedStatement, constraints: Seq[Constraint]): Either[Throwable, Unit] =
+        Try {
+            var idx = 1
+            for c <- constraints
+            do idx = c.bind(statement, idx)
+            log.atDebug.log(s"Bound ${idx - 1} constraints to prepared statement")
+        }.toEither
+
+    def buildPreparedStatementTemplate(
+        tableName: String,
+        querySelects: Seq[String],
+        constraints: Seq[Constraint],
+        includeConcurrentObservations: Boolean = false,
+        includeRelatedAssociations: Boolean = false
+    ): String =
+
+        val select = (ObservationUuid +: querySelects).mkString(", ")
+        val where = buildWhereClause(tableName, constraints, includeConcurrentObservations, includeRelatedAssociations)
+
+        s"""
+          |SELECT $select
+          |FROM $tableName
+          |WHERE $where
+          |""".stripMargin
+
+
+    private def buildWhereClause(tableName: String,
+                         constraints: Seq[Constraint],
+                         includeConcurrentObservations: Boolean = false,
+                         includeRelatedAssociations: Boolean = false): String =
+        val wheres  = constraints.map(_.toPreparedStatementTemplate).mkString(" AND ")
+        if includeConcurrentObservations && includeRelatedAssociations then
+            s"""WHERE $ObservationUuid IN (
+               |     SELECT $ObservationUuid
+               |     FROM $tableName
+               |     WHERE $ImagedMomentUuid IN (
+               |          SELECT $ImagedMomentUuid
+               |          FROM $tableName
+               |          WHERE $wheres
+               |     )
+               |)
+               |""".stripMargin
+        else if includeConcurrentObservations then
+            s"""WHERE $ImagedMomentUuid IN (
+               |     SELECT $ImagedMomentUuid
+               |     FROM $tableName
+               |     WHERE $wheres
+               |)
+               |""".stripMargin
+        else if includeRelatedAssociations then
+            s"""WHERE $ObservationUuid IN (
+               |     SELECT $ObservationUuid
+               |     FROM $tableName
+               |     WHERE $wheres
+               |)
+               |""".stripMargin
+        else
+            s"""WHERE $wheres"""
+}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
@@ -69,7 +69,7 @@ object PreparedStatementGenerator:
           |""".stripMargin
 
     private def buildSelectClause(query: Query): String =
-        if query.strict then query.where.map(_.column).mkString(", ")
+        if query.strict then query.select.mkString(", ")
         else
             // Add InexTime to the columns if it is not already there so that we can always sort by time
             val resolvedColumns1 =

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
@@ -20,7 +20,7 @@ import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
 
 import java.sql.PreparedStatement
 import scala.util.Try
-object PreparedStatementGenerator {
+object PreparedStatementGenerator:
 
     val IndexTime        = "index_recorded_timestamp"
     val ObservationUuid  = "observation_uuid"
@@ -84,8 +84,7 @@ object PreparedStatementGenerator {
         query: Query
     ): String =
         val wheres = query.where.map(_.toPreparedStatementTemplate).mkString(" AND ")
-        if query.concurrentObservations && query.relatedAssociations then
-            s"""WHERE $ObservationUuid IN (
+        if query.concurrentObservations && query.relatedAssociations then s"""WHERE $ObservationUuid IN (
                |     SELECT $ObservationUuid
                |     FROM $tableName
                |     WHERE $ImagedMomentUuid IN (
@@ -108,4 +107,3 @@ object PreparedStatementGenerator {
                |)
                |""".stripMargin
         else s"""WHERE $wheres"""
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/PreparedStatementGenerator.scala
@@ -83,27 +83,29 @@ object PreparedStatementGenerator:
         tableName: String,
         query: Query
     ): String =
-        val wheres = query.where.map(_.toPreparedStatementTemplate).mkString(" AND ")
-        if query.concurrentObservations && query.relatedAssociations then s"""WHERE $ObservationUuid IN (
-               |     SELECT $ObservationUuid
-               |     FROM $tableName
-               |     WHERE $ImagedMomentUuid IN (
-               |          SELECT $ImagedMomentUuid
-               |          FROM $tableName
-               |          WHERE $wheres
-               |     )
-               |)
-               |""".stripMargin
-        else if query.concurrentObservations then s"""WHERE $ImagedMomentUuid IN (
-               |     SELECT $ImagedMomentUuid
-               |     FROM $tableName
-               |     WHERE $wheres
-               |)
-               |""".stripMargin
-        else if query.relatedAssociations then s"""WHERE $ObservationUuid IN (
-               |     SELECT $ObservationUuid
-               |     FROM $tableName
-               |     WHERE $wheres
-               |)
-               |""".stripMargin
-        else s"""WHERE $wheres"""
+        if (query.where.isEmpty) ""
+        else
+            val wheres = query.where.map(_.toPreparedStatementTemplate).mkString(" AND ")
+            if query.concurrentObservations && query.relatedAssociations then s"""WHERE $ObservationUuid IN (
+                   |     SELECT $ObservationUuid
+                   |     FROM $tableName
+                   |     WHERE $ImagedMomentUuid IN (
+                   |          SELECT $ImagedMomentUuid
+                   |          FROM $tableName
+                   |          WHERE $wheres
+                   |     )
+                   |)
+                   |""".stripMargin
+            else if query.concurrentObservations then s"""WHERE $ImagedMomentUuid IN (
+                   |     SELECT $ImagedMomentUuid
+                   |     FROM $tableName
+                   |     WHERE $wheres
+                   |)
+                   |""".stripMargin
+            else if query.relatedAssociations then s"""WHERE $ObservationUuid IN (
+                   |     SELECT $ObservationUuid
+                   |     FROM $tableName
+                   |     WHERE $wheres
+                   |)
+                   |""".stripMargin
+            else s"""WHERE $wheres"""

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryResults.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryResults.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.repository.query
+
+import java.sql.ResultSet
+import scala.collection.mutable
+
+type QueryResults = Map[JDBC.Metadata, Seq[Any]]
+
+object QueryResults {
+
+    def fromResultSet(rs: ResultSet): QueryResults =
+        val metadata = JDBC.Metadata.fromResultSet(rs)
+        val map = scala.collection.mutable.Map[JDBC.Metadata, mutable.ListBuffer[Any]]()
+        while rs.next() do
+            metadata.foreach { m =>
+                val list = map.getOrElseUpdate(m, mutable.ListBuffer())
+                list += rs.getObject(m.columnName)
+            }
+        val data = map.map { case (k, v) => k -> v.result() }.toMap
+        data
+
+
+}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
@@ -25,7 +25,7 @@ import java.sql.ResultSet
 import scala.collection.mutable.ListBuffer
 import scala.util.Using
 
-class QueryService(databaseConfig: DatabaseConfig, viewName: String) {
+class QueryService(databaseConfig: DatabaseConfig, viewName: String):
 
     val jdbc               = new JDBC(databaseConfig)
     val AnnotationViewName = "annotations"
@@ -34,7 +34,7 @@ class QueryService(databaseConfig: DatabaseConfig, viewName: String) {
     def findAllConceptNames(): Either[Throwable, Seq[String]] =
         jdbc.findDistinct(viewName, "concept", stringConverter)
 
-    def findAssociationsForConcepts(concepts: Seq[String]): Either[Throwable, Seq[Association]] = {
+    def findAssociationsForConcepts(concepts: Seq[String]): Either[Throwable, Seq[Association]] =
         val sql = s"""
            | SELECT DISTINCT
            |   link_name,
@@ -48,19 +48,15 @@ class QueryService(databaseConfig: DatabaseConfig, viewName: String) {
            |""".stripMargin
         jdbc.runQuery(
             sql,
-            rs => {
+            rs =>
                 val associations = ListBuffer.newBuilder[Association]
-                while (rs.next()) {
+                while rs.next() do
                     val linkName  = rs.getString("link_name")
                     val toConcept = rs.getString("to_concept")
                     val linkValue = rs.getString("link_value")
                     associations += Association(linkName, toConcept, linkValue)
-                }
                 associations.result().toSeq.sortBy(_.linkName)
-            }
         )
-
-    }
 
     def count(query: Query): Either[Throwable, Int] =
         val sql = PreparedStatementGenerator.buildPreparedStatementTemplateForCounts(
@@ -80,7 +76,7 @@ class QueryService(databaseConfig: DatabaseConfig, viewName: String) {
                     )
                 )
                 PreparedStatementGenerator.bind(stmt, query.where)
-                val rs = stmt.executeQuery()
+                val rs   = stmt.executeQuery()
                 //                val rs   = use(stmt.executeQuery(sql))
                 if rs.next() then rs.getInt(1) else 0
             )
@@ -105,9 +101,7 @@ class QueryService(databaseConfig: DatabaseConfig, viewName: String) {
                 query.limit.foreach(stmt.setMaxRows)
                 query.offset.foreach(stmt.setFetchSize)
                 PreparedStatementGenerator.bind(stmt, query.where)
-                val rs = stmt.executeQuery()
+                val rs   = stmt.executeQuery()
                 QueryResults.fromResultSet(rs)
             )
             .toEither
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
@@ -17,9 +17,9 @@
 package org.mbari.annosaurus.repository.query
 
 import org.mbari.annosaurus.DatabaseConfig
-import org.mbari.annosaurus.repository.jdbc.*
-import org.mbari.annosaurus.domain.{Annotation, Association}
+import org.mbari.annosaurus.domain.Association
 import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+import org.mbari.annosaurus.repository.jdbc.*
 
 import java.sql.ResultSet
 import scala.collection.mutable.ListBuffer

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.repository.query
+
+import org.mbari.annosaurus.DatabaseConfig
+import org.mbari.annosaurus.repository.jdbc.*
+import org.mbari.annosaurus.domain.{Annotation, Association}
+
+import java.sql.ResultSet
+import scala.collection.mutable.ListBuffer
+import scala.util.Using
+
+
+class QueryService(databaseConfig: DatabaseConfig, viewName: String) {
+
+    private val jdbc = new JDBC(databaseConfig)
+    val AnnotationViewName = "annotations"
+
+    def findAllConceptNames(): Either[Throwable, Seq[String]] =
+        jdbc.findDistinct(viewName, "concept", stringConverter)
+
+    def findAssociationsForConcepts(concepts: Seq[String]): Either[Throwable, Seq[Association]] = {
+        val sql = s"""
+           | SELECT DISTINCT
+           |   link_name,
+           |   to_concept,
+           |   link_value
+           | FROM
+           |   associations AS a JOIN
+           |   observations AS o ON o.uuid = a.observation_uuid
+           | WHERE
+           |   concept IN (${concepts.map(s => s"'$s'").mkString(",")})
+           |""".stripMargin
+        jdbc.runQuery(sql, rs => {
+            val associations = ListBuffer.newBuilder[Association]
+            while (rs.next()) {
+                val linkName = rs.getString("link_name")
+                val toConcept = rs.getString("to_concept")
+                val linkValue = rs.getString("link_value")
+                associations += Association(linkName, toConcept, linkValue)
+            }
+            associations.result().toSeq.sortBy(_.linkName)
+        })
+
+    }
+
+    def query(querySelects: Seq[String],
+              constraints: Seq[Constraint],
+              includeConcurrentObservations: Boolean = false,
+              includeRelatedAssociations: Boolean = false): Either[Throwable, QueryResults] =
+        val sql = PreparedStatementGenerator.buildPreparedStatementTemplate(
+            viewName,
+            querySelects,
+            constraints,
+            includeConcurrentObservations,
+            includeRelatedAssociations
+        )
+        Using.Manager(use =>
+            val conn = use(jdbc.newConnection())
+            conn.setReadOnly(true)
+            val stmt = use(conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))
+            PreparedStatementGenerator.bind(stmt, constraints)
+            val rs = use(stmt.executeQuery(sql))
+            QueryResults.fromResultSet(rs)
+        ).toEither
+
+
+
+
+
+
+
+
+
+}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
@@ -17,19 +17,16 @@
 package org.mbari.annosaurus.repository.query
 
 import org.mbari.annosaurus.DatabaseConfig
-import org.mbari.annosaurus.domain.Association
 import org.mbari.annosaurus.etc.jdk.Loggers.{*, given}
-import org.mbari.annosaurus.repository.jdbc.*
 
 import java.sql.ResultSet
-import scala.collection.mutable.ListBuffer
 import scala.util.Using
 
 class QueryService(databaseConfig: DatabaseConfig, viewName: String):
 
-    val jdbc               = new JDBC(databaseConfig)
+    val jdbc        = new JDBC(databaseConfig)
 //    val AnnotationViewName = "annotations"
-    private val log        = System.getLogger(getClass.getName)
+    private val log = System.getLogger(getClass.getName)
 
 //    def findAllConceptNames(): Either[Throwable, Seq[String]] =
 //        jdbc.findDistinct(viewName, "concept", stringConverter)

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
@@ -28,35 +28,35 @@ import scala.util.Using
 class QueryService(databaseConfig: DatabaseConfig, viewName: String):
 
     val jdbc               = new JDBC(databaseConfig)
-    val AnnotationViewName = "annotations"
+//    val AnnotationViewName = "annotations"
     private val log        = System.getLogger(getClass.getName)
 
-    def findAllConceptNames(): Either[Throwable, Seq[String]] =
-        jdbc.findDistinct(viewName, "concept", stringConverter)
-
-    def findAssociationsForConcepts(concepts: Seq[String]): Either[Throwable, Seq[Association]] =
-        val sql = s"""
-           | SELECT DISTINCT
-           |   link_name,
-           |   to_concept,
-           |   link_value
-           | FROM
-           |   associations AS a JOIN
-           |   observations AS o ON o.uuid = a.observation_uuid
-           | WHERE
-           |   concept IN (${concepts.map(s => s"'$s'").mkString(",")})
-           |""".stripMargin
-        jdbc.runQuery(
-            sql,
-            rs =>
-                val associations = ListBuffer.newBuilder[Association]
-                while rs.next() do
-                    val linkName  = rs.getString("link_name")
-                    val toConcept = rs.getString("to_concept")
-                    val linkValue = rs.getString("link_value")
-                    associations += Association(linkName, toConcept, linkValue)
-                associations.result().toSeq.sortBy(_.linkName)
-        )
+//    def findAllConceptNames(): Either[Throwable, Seq[String]] =
+//        jdbc.findDistinct(viewName, "concept", stringConverter)
+//
+//    def findAssociationsForConcepts(concepts: Seq[String]): Either[Throwable, Seq[Association]] =
+//        val sql = s"""
+//           | SELECT DISTINCT
+//           |   link_name,
+//           |   to_concept,
+//           |   link_value
+//           | FROM
+//           |   associations AS a JOIN
+//           |   observations AS o ON o.uuid = a.observation_uuid
+//           | WHERE
+//           |   concept IN (${concepts.map(s => s"'$s'").mkString(",")})
+//           |""".stripMargin
+//        jdbc.runQuery(
+//            sql,
+//            rs =>
+//                val associations = ListBuffer.newBuilder[Association]
+//                while rs.next() do
+//                    val linkName  = rs.getString("link_name")
+//                    val toConcept = rs.getString("to_concept")
+//                    val linkValue = rs.getString("link_value")
+//                    associations += Association(linkName, toConcept, linkValue)
+//                associations.result().toSeq.sortBy(_.linkName)
+//        )
 
     def count(query: Query): Either[Throwable, Int] =
         val sql = PreparedStatementGenerator.buildPreparedStatementTemplateForCounts(

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/QueryService.scala
@@ -18,7 +18,7 @@ package org.mbari.annosaurus.repository.query
 
 import org.mbari.annosaurus.DatabaseConfig
 import org.mbari.annosaurus.domain.Association
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
+import org.mbari.annosaurus.etc.jdk.Loggers.{*, given}
 import org.mbari.annosaurus.repository.jdbc.*
 
 import java.sql.ResultSet

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/constraints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/constraints.scala
@@ -24,15 +24,15 @@ import java.time.Instant
 
 // Define the Root case class
 case class Query(
-    where: Seq[Constraint],
     select: Seq[String] = Seq.empty,
+    distinct: Boolean = false,
+    where: Seq[Constraint] = Seq.empty,
+    orderby: Option[Seq[String]] = None,
     limit: Option[Int] = None,
     offset: Option[Int] = None,
     concurrentObservations: Boolean = false,
     relatedAssociations: Boolean = false,
-    distinct: Boolean = true,
-    strict: Boolean = false,
-    orderby: Option[Seq[String]] = None
+    strict: Boolean = true
 )
 
 object Query:
@@ -50,15 +50,19 @@ object Query:
         else Right(from(queryRequest))
 
     def from(queryRequest: QueryRequest): Query =
+        val strict = if (queryRequest.concurrentObservations.getOrElse(false) || queryRequest.relatedAssociations.getOrElse(false))
+            false
+        else queryRequest.strict.getOrElse(true)
+
         Query(
-            where = queryRequest.where.map(Constraint.from),
+            where = queryRequest.where.getOrElse(Seq.empty).map(Constraint.from),
             select = queryRequest.select.getOrElse(Seq.empty),
             limit = queryRequest.limit,
             offset = queryRequest.offset,
             concurrentObservations = queryRequest.concurrentObservations.getOrElse(false),
             relatedAssociations = queryRequest.relatedAssociations.getOrElse(false),
-            distinct = queryRequest.distinct.getOrElse(true),
-            strict = queryRequest.strict.getOrElse(false),
+            distinct = queryRequest.distinct.getOrElse(false),
+            strict = strict,
             orderby = queryRequest.orderby
         )
 

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/constraints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/constraints.scala
@@ -37,7 +37,11 @@ case class Query(
 
 object Query:
 
-    def validate(queryRequest: QueryRequest, checkWhere: Boolean = true, checkSelect: Boolean = true): Either[Throwable, Query] =
+    def validate(
+        queryRequest: QueryRequest,
+        checkWhere: Boolean = true,
+        checkSelect: Boolean = true
+    ): Either[Throwable, Query] =
         val query = from(queryRequest)
         if checkWhere && query.where.isEmpty then Left(new IllegalArgumentException("where clause is required"))
         else if checkSelect && query.select.isEmpty then Left(new IllegalArgumentException("select clause is required"))

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/constraints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/constraints.scala
@@ -17,10 +17,10 @@
 package org.mbari.annosaurus.repository.query
 
 import org.mbari.annosaurus.domain.{ConstraintRequest, QueryRequest}
+import org.mbari.annosaurus.etc.circe.CirceCodecs.*
 
 import java.sql.{PreparedStatement, SQLException}
 import java.time.Instant
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 
 // Define the Root case class
 case class Query(

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/constraints.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/query/constraints.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.repository.query
+
+import java.sql.{PreparedStatement, SQLException}
+import java.time.Instant
+
+import java.time.Instant
+
+
+// Define the Root case class
+case class Constraints(constraints: List[Constraint])
+
+sealed trait Constraint:
+    def columnName: String
+    def toPreparedStatementTemplate: String
+
+    @throws[SQLException]
+    def bind(statement: PreparedStatement, idx: Int): Int
+
+object Constraint:
+    object Noop extends Constraint:
+        val columnName: String = ""
+        def toPreparedStatementTemplate: String = ""
+        @throws[SQLException]
+        def bind(statement: PreparedStatement, idx: Int): Int = idx
+
+    case class In[A](columnName: String, in: Seq[A]) extends Constraint:
+        require(columnName != null)
+        require(in != null && in.nonEmpty, "Check your value arg! null and empty values are not allowed")
+
+        @throws[SQLException]
+        def bind(statement: PreparedStatement, idx: Int): Int =
+            var i = idx
+            for v <- in do
+                statement.setObject(idx, v)
+                i = i + 1
+            i
+
+        def toPreparedStatementTemplate: String =
+            if in.size eq 1 then columnName + " = ?"
+            else columnName + " IN " + in.map(s => "?").mkString("(", ",", ")")
+
+    case class Like(columnName: String, like: String) extends Constraint:
+        @throws[SQLException]
+        def bind(statement: PreparedStatement, idx: Int): Int =
+            statement.setString(idx, s"%$like%")
+            idx + 1
+
+        def toPreparedStatementTemplate: String = s"$columnName LIKE ?"
+
+    case class Max(columnName: String, max: Double) extends Constraint:
+        @throws[SQLException]
+        def bind(statement: PreparedStatement, idx: Int): Int =
+            statement.setDouble(idx, max)
+            idx + 1
+
+        def toPreparedStatementTemplate: String = columnName + " <= ?"
+
+    case class Min(columnName: String, min: Double) extends Constraint:
+        @throws[SQLException]
+        def bind(statement: PreparedStatement, idx: Int): Int =
+            statement.setDouble(idx, min)
+            idx + 1
+
+        def toPreparedStatementTemplate: String = columnName + " >= ?"
+
+    case class MinMax(columnName: String, min: Double, max: Double) extends Constraint:
+        @throws[SQLException]
+        def bind(statement: PreparedStatement, idx: Int): Int =
+            statement.setDouble(idx, min)
+            statement.setDouble(idx + 1, max)
+            idx + 2
+
+        def toPreparedStatementTemplate: String = columnName + " BETWEEN ? AND ?"
+
+    case class Date(columnName: String, startTimestamp: Instant, endTimestamp: Instant) extends Constraint:
+        @throws[SQLException]
+        def bind(statement: PreparedStatement, idx: Int): Int =
+            statement.setObject(idx, startTimestamp)
+            statement.setObject(idx + 1, endTimestamp)
+            idx + 2
+
+        def toPreparedStatementTemplate: String = columnName + " BETWEEN ? AND ?"
+
+
+//
+//case class InConstraint[A](columnName: String, in: Seq[A]) extends Constraint {
+//    require(columnName != null)
+//    require(in != null && in.nonEmpty, "Check your value arg! null and empty values are not allowed")
+//
+//    @throws[SQLException]
+//    def bind(statement: PreparedStatement, idx: Int): Int = {
+//        var i = idx
+//        for (v <- in) {
+//            statement.setObject(idx, v)
+//            i = i + 1
+//        }
+//        i
+//    }
+//
+//    def toPreparedStatementTemplate: String = if (in.size eq 1) columnName + " = ?"
+//    else columnName + " IN " + in.map(s => "?").mkString("(", ",", ")")
+//}
+//
+//case class LikeConstraint(columnName: String, like: String) extends Constraint {
+//    @throws[SQLException]
+//    def bind(statement: PreparedStatement, idx: Int): Int = {
+//        statement.setString(idx, s"%$like%")
+//        idx + 1
+//    }
+//
+//    def toPreparedStatementTemplate: String = s"$columnName LIKE ?"
+//}
+//
+//case class MaxConstraint(columnName: String, max: Double) extends Constraint {
+//    @throws[SQLException]
+//    def bind(statement: PreparedStatement, idx: Int): Int = {
+//        statement.setDouble(idx, max)
+//        idx + 1
+//    }
+//
+//    def toPreparedStatementTemplate: String = columnName + " <= ?"
+//}
+//
+//case class MinConstraint(columnName: String, min: Double) extends Constraint {
+//    @throws[SQLException]
+//    def bind(statement: PreparedStatement, idx: Int): Int = {
+//        statement.setDouble(idx, min)
+//        idx + 1
+//    }
+//
+//    def toPreparedStatementTemplate: String = columnName + " >= ?"
+//}
+//
+//case class MinMaxConstraint(columnName: String, min: Double, max: Double) extends Constraint {
+//    @throws[SQLException]
+//    def bind(statement: PreparedStatement, idx: Int): Int = {
+//        statement.setDouble(idx, min)
+//        statement.setDouble(idx + 1, max)
+//        idx + 2
+//    }
+//
+//    def toPreparedStatementTemplate: String = columnName + " BETWEEN ? AND ?"
+//}
+//
+//case class DateConstraint(columnName: String, startTimestamp: Instant, endTimestamp: Instant) extends Constraint:
+//    @throws[SQLException]
+//    def bind(statement: PreparedStatement, idx: Int): Int = {
+//        statement.setObject(idx, min)
+//        statement.setObject(idx + 1, max)
+//        idx + 2
+//    }
+//
+//    def toPreparedStatementTemplate: String = columnName + " BETWEEN ? AND ?"
+//
+//
+

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/repository/repository.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/repository/repository.scala
@@ -16,12 +16,12 @@
 
 package org.mbari.annosaurus
 
-/** The Data Access Objects provide the base methods for interacting with the data storage. As the
-  * most common storage are likely to be SQL Databases, the DAO are likely to do blocking IO (e.g.
-  * JDBC).
-  *
-  * @author
-  *   Brian Schlining
-  * @since 2016-07-11T10:56:00
-  */
+/**
+ * The Data Access Objects provide the base methods for interacting with the data storage. As the most common storage
+ * are likely to be SQL Databases, the DAO are likely to do blocking IO (e.g. JDBC).
+ *
+ * @author
+ *   Brian Schlining
+ * @since 2016-07-11T10:56:00
+ */
 package object repository {}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/util/FastCollator.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/util/FastCollator.scala
@@ -20,17 +20,18 @@ import org.mbari.scilube3.Matlib
 
 import scala.math.Ordering.Double.IeeeOrdering
 
-/** @author
-  *   Brian Schlining
-  * @since 2015-03-02T16:20:00
-  */
-object FastCollator {
+/**
+ * @author
+ *   Brian Schlining
+ * @since 2015-03-02T16:20:00
+ */
+object FastCollator:
 
     def apply[A: Numeric, B: Numeric](
         a: Iterable[A],
         b: Iterable[B],
         tolerance: Double
-    ): Seq[(A, Option[B])] = {
+    ): Seq[(A, Option[B])] =
         val numericA = implicitly[Numeric[A]]
         val numericB = implicitly[Numeric[B]]
 
@@ -39,15 +40,13 @@ object FastCollator {
 
         apply(a, fa, b, fb, tolerance)
 
-    }
-
     def apply[A, B](
         a: Iterable[A],
         fnA: A => Double,
         b: Iterable[B],
         fnB: B => Double,
         tolerance: Double
-    ): Seq[(A, Option[B])] = {
+    ): Seq[(A, Option[B])] =
 
         val listA = a.toSeq.sortBy(fnA) // sorted d0
         val listB = b.toSeq.sortBy(fnB) // sorted d1
@@ -55,19 +54,14 @@ object FastCollator {
         val valuesA = listA.map(fnA).toArray // transformed d0 in same order as list0
         val valuesB = listB.map(fnB).toArray // transformed d1 in same order as list1
 
-        val tmp = for {
-            (vA, iA) <- valuesA.zipWithIndex
-        } yield {
-            val iB      = Matlib.near(valuesB, vA, false)
-            val nearest = if (iB >= 0) {
-                val vB = valuesB(iB)
-                if (math.abs(vA - vB) <= tolerance) Option(listB(iB))
+        val tmp =
+            for (vA, iA) <- valuesA.zipWithIndex
+            yield
+                val iB      = Matlib.near(valuesB, vA, false)
+                val nearest = if iB >= 0 then
+                    val vB = valuesB(iB)
+                    if math.abs(vA - vB) <= tolerance then Option(listB(iB))
+                    else None
                 else None
-            }
-            else None
-            listA(iA) -> nearest
-        }
+                listA(iA) -> nearest
         tmp.toSeq
-    }
-
-}

--- a/annosaurus/src/main/scala/org/mbari/annosaurus/util/HexUtil.scala
+++ b/annosaurus/src/main/scala/org/mbari/annosaurus/util/HexUtil.scala
@@ -16,18 +16,14 @@
 
 package org.mbari.annosaurus.util
 
-object HexUtil {
-    def toHex(bytes: Array[Byte]): String = {
+object HexUtil:
+    def toHex(bytes: Array[Byte]): String =
         val sb = new StringBuilder
-        for (b <- bytes)
-            sb.append(String.format("%02x", Byte.box(b)))
+        for b <- bytes do sb.append(String.format("%02x", Byte.box(b)))
         sb.toString
-    }
 
-    def fromHex(hex: String): Array[Byte] = {
+    def fromHex(hex: String): Array[Byte] =
         hex
             .grouped(2)
             .toArray
             .map(i => Integer.parseInt(i, 16).toByte)
-    }
-}

--- a/annosaurus/src/test/resources/json/constraints.json
+++ b/annosaurus/src/test/resources/json/constraints.json
@@ -1,7 +1,8 @@
 {
-  "constraints": [
+  "select": ["foo"],
+  "where": [
     {
-      "columnName": "id",
+      "column": "id",
       "in": [
         "1",
         "2",
@@ -9,46 +10,47 @@
       ]
     },
     {
-      "columnName": "name",
+      "column": "name",
       "like": ".*"
     },
     {
-      "columnName": "age",
+      "column": "age",
       "minmax": [
         1,
         100
       ]
     },
     {
-      "columnName": "height",
-      "between": [
-        1,
-        100
-      ]
-    },
-    {
-      "columnName": "foo",
+      "column": "foo",
       "min": 1
     },
     {
-      "columnName": "bar",
+      "column": "bar",
       "max": 100
     },
     {
-      "columnName": "baz",
+      "column": "baz",
       "between": [
         "2010-01-01T01:22:33Z",
         "2011-01-01T01:22:33Z"
       ]
     },
     {
-      "columnName": "qux",
+      "column": "qux",
       "isnull": true
     },
 
     {
-      "columnName": "quxx",
+      "column": "quxx",
       "isnull": false
+    },
+    {
+      "column": "quxxx",
+      "equals": "foo"
+    },
+    {
+      "column": "zzzz",
+      "contains": "foo"
     }
 
   ]

--- a/annosaurus/src/test/resources/json/constraints.json
+++ b/annosaurus/src/test/resources/json/constraints.json
@@ -1,0 +1,38 @@
+{
+  "constraints": [
+    {
+      "columnName": "id",
+      "in": [
+        "1",
+        "2",
+        "3"
+      ]
+    },
+    {
+      "columnName": "name",
+      "like": ".*"
+    },
+    {
+      "columnName": "age",
+      "minmax": [
+        1,
+        100
+      ]
+    },
+    {
+      "columnName": "foo",
+      "min": 1
+    },
+    {
+      "columnName": "bar",
+      "max": 100
+    },
+    {
+      "columnName": "baz",
+      "between": [
+        "2010-01-01T01:22:33Z",
+        "2011-01-01T01:22:33Z"
+      ]
+    }
+  ]
+}

--- a/annosaurus/src/test/resources/json/constraints.json
+++ b/annosaurus/src/test/resources/json/constraints.json
@@ -20,6 +20,13 @@
       ]
     },
     {
+      "columnName": "height",
+      "between": [
+        1,
+        100
+      ]
+    },
+    {
       "columnName": "foo",
       "min": 1
     },
@@ -33,6 +40,16 @@
         "2010-01-01T01:22:33Z",
         "2011-01-01T01:22:33Z"
       ]
+    },
+    {
+      "columnName": "qux",
+      "isnull": true
+    },
+
+    {
+      "columnName": "quxx",
+      "isnull": false
     }
+
   ]
 }

--- a/annosaurus/src/test/scala/org/mbari/annosaurus/etc/circe/CirceCodecsSuite.scala
+++ b/annosaurus/src/test/scala/org/mbari/annosaurus/etc/circe/CirceCodecsSuite.scala
@@ -20,7 +20,7 @@ import scala.io.Source
 import scala.util.Using
 import org.mbari.annosaurus.domain.{ImagedMoment, ImagedMomentSC, ObservationsUpdate, QueryConstraints}
 import CirceCodecs.{*, given}
-import org.mbari.annosaurus.repository.query.Constraints
+import org.mbari.annosaurus.repository.query.Query
 
 import scala.util.Failure
 import scala.util.Success
@@ -309,7 +309,7 @@ class CirceCodecsSuite extends munit.FunSuite {
         val t   = Using(Source.fromURL(url)) { source =>
             val json = source.getLines().mkString
             assert(json != null)
-            val opt = json.reify[Constraints].toOption
+            val opt = json.reify[Query].toOption
             assert(opt.isDefined)
             val constraints = opt.get.constraints
             assertEquals(constraints.size, 9)

--- a/annosaurus/src/test/scala/org/mbari/annosaurus/etc/circe/CirceCodecsSuite.scala
+++ b/annosaurus/src/test/scala/org/mbari/annosaurus/etc/circe/CirceCodecsSuite.scala
@@ -20,6 +20,7 @@ import scala.io.Source
 import scala.util.Using
 import org.mbari.annosaurus.domain.{ImagedMoment, ImagedMomentSC, ObservationsUpdate, QueryConstraints}
 import CirceCodecs.{*, given}
+import org.mbari.annosaurus.repository.query.Constraints
 
 import scala.util.Failure
 import scala.util.Success
@@ -300,6 +301,19 @@ class CirceCodecsSuite extends munit.FunSuite {
         assertEquals(ou.concept, Some("Grimpoteuthis"))
         assertEquals(ou.observer, Some("svonthun"))
         assertEquals(ou.group, Some("ROV"))
+    }
+
+    test("decode constraints") {
+        val url = getClass.getResource("/json/constraints.json")
+        assert(url != null)
+        val t   = Using(Source.fromURL(url)) { source =>
+            val json = source.getLines().mkString
+            assert(json != null)
+            val opt = json.reify[Constraints].toOption
+            assert(opt.isDefined)
+            val constraints = opt.get.constraints
+            assertEquals(constraints.size, 6)
+        }
     }
 
 }

--- a/annosaurus/src/test/scala/org/mbari/annosaurus/etc/circe/CirceCodecsSuite.scala
+++ b/annosaurus/src/test/scala/org/mbari/annosaurus/etc/circe/CirceCodecsSuite.scala
@@ -312,7 +312,8 @@ class CirceCodecsSuite extends munit.FunSuite {
             val opt = json.reify[Constraints].toOption
             assert(opt.isDefined)
             val constraints = opt.get.constraints
-            assertEquals(constraints.size, 6)
+            assertEquals(constraints.size, 9)
+            println(constraints)
         }
     }
 

--- a/annosaurus/src/test/scala/org/mbari/annosaurus/etc/circe/CirceCodecsSuite.scala
+++ b/annosaurus/src/test/scala/org/mbari/annosaurus/etc/circe/CirceCodecsSuite.scala
@@ -317,7 +317,7 @@ class CirceCodecsSuite extends munit.FunSuite {
         yield
             val constraints = query.where
             assertEquals(constraints.size, 10)
-            println(query.where)
+//            println(query.where)
 
         attempt match
             case Left(e) =>

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,12 @@ ThisBuild / scalacOptions ++= Seq(
     "-language:existentials",
     "-language:higherKinds",
     "-language:implicitConversions",
-    "-unchecked"
+    "-unchecked",
+    "-Wunused:imports"
 )
+ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
+
 ThisBuild / startYear        := Some(2017)
 //ThisBuild / updateOptions    := updateOptions.value.withCachedResolution(true)
 ThisBuild / versionScheme    := Some("semver-spec")

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / licenses         := Seq("Apache-2.0" -> url("http://www.apache.org/l
 ThisBuild / organization     := "org.mbari"
 ThisBuild / organizationName := "Monterey Bay Aquarium Research Institute"
 ThisBuild / resolvers ++= Seq(Resolver.githubPackages("mbari-org", "maven"))
-ThisBuild / scalaVersion     := "3.5.0"
+ThisBuild / scalaVersion     := "3.5.1"
 // ThisBuild / scalaVersion     := "3.3.1" // Fails. See https://github.com/lampepfl/dotty/issues/17069#issuecomment-1763053572
 ThisBuild / scalacOptions ++= Seq(
     "-deprecation",  // Emit warning and location for usages of deprecated APIs.

--- a/build.sh
+++ b/build.sh
@@ -34,4 +34,4 @@ fi
 
 
 # sbt pack && \
-#     docker build -t mbari/annosaurus:latest
+#     docker build -t mbari/annosaurus:latest .

--- a/it-postgres/src/test/resources/sql/postgresql/02_m3_annotations.sql
+++ b/it-postgres/src/test/resources/sql/postgresql/02_m3_annotations.sql
@@ -131,6 +131,60 @@ CREATE  INDEX "idx_observations__imaged_moment_uuid"
 CREATE  INDEX "idx_video_reference_information__video_reference_uuid"
 	ON "video_reference_information"("video_reference_uuid");
 
+CREATE VIEW "annotations"
+AS
+    SELECT
+        im.uuid AS imaged_moment_uuid,
+        im.elapsed_time_millis AS index_elapsed_time_millis,
+        im.recorded_timestamp AS index_recorded_timestamp,
+        im.timecode AS index_timecode,
+        obs.uuid AS observation_uuid,
+        obs.activity,
+        obs.concept,
+        obs.duration_millis,
+        obs.observation_group,
+        obs.observation_timestamp,
+        obs.observer,
+        ir.uuid AS image_reference_uuid,
+        ir.description AS image_description,
+        ir.format AS image_format,
+        ir.height_pixels AS image_height,
+        ir.width_pixels AS image_width,
+        ir.url AS image_url,
+        ass.link_name,
+        ass.link_value,
+        ass.to_concept,
+        ass.mime_type AS association_mime_type,
+        ass.link_name || ' | ' || ass.to_concept || ' | ' || ass.link_value AS associations,
+        ad.altitude,
+        ad.coordinate_reference_system,
+        ad.depth_meters,
+        ad.latitude,
+        ad.longitude,
+        ad.oxygen_ml_per_l,
+        ad.phi,
+        ad.xyz_position_units,
+        ad.pressure_dbar,
+        ad.psi,
+        ad.salinity,
+        ad.temperature_celsius,
+        ad.theta,
+        ad.x,
+        ad.y,
+        ad.z,
+        ad.light_transmission,
+        info.mission_contact AS chief_scientist,
+        info.mission_id AS dive_number,
+        info.platform_name AS camera_platform
+    FROM
+        imaged_moments im
+        LEFT JOIN observations obs ON obs.imaged_moment_uuid = im.uuid
+        LEFT JOIN image_references ir ON ir.imaged_moment_uuid = im.uuid
+        LEFT JOIN associations ass ON ass.observation_uuid = obs.uuid
+        LEFT JOIN ancillary_data  ad ON ad.imaged_moment_uuid = im.uuid
+        LEFT JOIN video_reference_information info ON info.video_reference_uuid = im.video_reference_uuid;
+
+
 -- CREATE VIEW "annotations"
 -- AS
 --     SELECT

--- a/it-postgres/src/test/scala/org/mbari/annosaurus/endpoints/PostgresQueryEndpointsSuite.scala
+++ b/it-postgres/src/test/scala/org/mbari/annosaurus/endpoints/PostgresQueryEndpointsSuite.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.endpoints
+
+import org.mbari.annosaurus.repository.jpa.{PostgresTestDAOFactory, TestDAOFactory}
+
+class PostgresQueryEndpointsSuite extends QueryEndpointsSuite {
+    given daoFactory: TestDAOFactory = PostgresTestDAOFactory
+
+}

--- a/it-postgres/src/test/scala/org/mbari/annosaurus/repository/jpa/PostgresTestDAOFactory.scala
+++ b/it-postgres/src/test/scala/org/mbari/annosaurus/repository/jpa/PostgresTestDAOFactory.scala
@@ -17,7 +17,7 @@
 package org.mbari.annosaurus.repository.jpa
 
 import jakarta.persistence.EntityManagerFactory
-
+import org.mbari.annosaurus.DatabaseConfig
 import org.testcontainers.containers.PostgreSQLContainer
 
 object PostgresTestDAOFactory extends TestDAOFactory:
@@ -52,3 +52,11 @@ object PostgresTestDAOFactory extends TestDAOFactory:
             container.getDriverClassName(),
             testProps()
         )
+
+    lazy val databaseConfig: DatabaseConfig = DatabaseConfig(
+        container.getJdbcUrl(),
+        container.getUsername(),
+        container.getPassword(),
+        container.getDriverClassName(),
+        annotationView
+    )

--- a/it-postgres/src/test/scala/org/mbari/annosaurus/repository/query/PostgresQueryServiceSuite.scala
+++ b/it-postgres/src/test/scala/org/mbari/annosaurus/repository/query/PostgresQueryServiceSuite.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.repository.query
+
+import org.mbari.annosaurus.repository.jpa.{PostgresTestDAOFactory, TestDAOFactory}
+
+class PostgresQueryServiceSuite extends QueryServiceSuite {
+
+    given daoFactory: TestDAOFactory = PostgresTestDAOFactory
+
+}

--- a/it-sqlserver/src/test/resources/sql/mssqlserver/02_m3_annotations.sql
+++ b/it-sqlserver/src/test/resources/sql/mssqlserver/02_m3_annotations.sql
@@ -142,6 +142,60 @@ CREATE TABLE "dbo"."adjust_rov_tape_histories"  (
 	CONSTRAINT "PK_merge_rov_histories" PRIMARY KEY CLUSTERED("id")
  ON [PRIMARY]);
 
+CREATE VIEW "annotations"
+AS
+SELECT
+    im.uuid AS imaged_moment_uuid,
+    im.elapsed_time_millis AS index_elapsed_time_millis,
+    im.recorded_timestamp AS index_recorded_timestamp,
+    im.timecode AS index_timecode,
+    obs.uuid AS observation_uuid,
+    obs.activity,
+    obs.concept,
+    obs.duration_millis,
+    obs.observation_group,
+    obs.observation_timestamp,
+    obs.observer,
+    ir.uuid AS image_reference_uuid,
+    ir.description AS image_description,
+    ir.format AS image_format,
+    ir.height_pixels AS image_height,
+    ir.width_pixels AS image_width,
+    ir.url AS image_url,
+    ass.link_name,
+    ass.link_value,
+    ass.to_concept,
+    ass.mime_type AS association_mime_type,
+    CONCAT(ass.link_name, ' | ', ass.to_concept, ' | ', ass.link_value) AS associations,
+    ad.altitude,
+    ad.coordinate_reference_system,
+    ad.depth_meters,
+    ad.latitude,
+    ad.longitude,
+    ad.oxygen_ml_per_l,
+    ad.phi,
+    ad.xyz_position_units,
+    ad.pressure_dbar,
+    ad.psi,
+    ad.salinity,
+    ad.temperature_celsius,
+    ad.theta,
+    ad.x,
+    ad.y,
+    ad.z,
+    ad.light_transmission,
+    info.mission_contact AS chief_scientist,
+    info.mission_id AS dive_number,
+    info.platform_name AS camera_platform
+FROM
+    imaged_moments im
+        LEFT JOIN observations obs ON obs.imaged_moment_uuid = im.uuid
+        LEFT JOIN image_references ir ON ir.imaged_moment_uuid = im.uuid
+        LEFT JOIN associations ass ON ass.observation_uuid = obs.uuid
+        LEFT JOIN ancillary_data  ad ON ad.imaged_moment_uuid = im.uuid
+        LEFT JOIN video_reference_information info ON info.video_reference_uuid = im.video_reference_uuid;
+
+
 --  ALTER TABLE "dbo"."ancillary_data" WITH NOCHECK
 -- 	ADD CONSTRAINT "FK_ancillary_data_imaged_moment_uuid"
 -- 	FOREIGN KEY("imaged_moment_uuid")

--- a/it-sqlserver/src/test/scala/org/mbari/annosaurus/repository/jpa/SqlServerTestDAOFactory.scala
+++ b/it-sqlserver/src/test/scala/org/mbari/annosaurus/repository/jpa/SqlServerTestDAOFactory.scala
@@ -17,6 +17,7 @@
 package org.mbari.annosaurus.repository.jpa
 
 import jakarta.persistence.EntityManagerFactory
+import org.mbari.annosaurus.DatabaseConfig
 import org.mbari.annosaurus.etc.tc.AzureSqlEdgeContainerProvider
 
 object SqlServerTestDAOFactory extends TestDAOFactory:
@@ -56,3 +57,11 @@ object SqlServerTestDAOFactory extends TestDAOFactory:
             container.getDriverClassName(),
             testProps()
         )
+
+    lazy val databaseConfig: DatabaseConfig = DatabaseConfig(
+        container.getJdbcUrl(),
+        container.getUsername(),
+        container.getPassword(),
+        container.getDriverClassName(),
+        annotationView
+    )

--- a/it-sqlserver/src/test/scala/org/mbari/annosaurus/repository/query/SqlServerQueryServiceSuite.scala
+++ b/it-sqlserver/src/test/scala/org/mbari/annosaurus/repository/query/SqlServerQueryServiceSuite.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.repository.query
+
+import org.mbari.annosaurus.repository.jpa.{SqlServerTestDAOFactory, TestDAOFactory}
+
+class SqlServerQueryServiceSuite extends QueryServiceSuite {
+
+  given daoFactory: TestDAOFactory = SqlServerTestDAOFactory
+
+}

--- a/it/src/main/scala/org/mbari/annosaurus/AssertUtils.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/AssertUtils.scala
@@ -17,7 +17,15 @@
 package org.mbari.annosaurus
 
 import org.junit.Assert.*
-import org.mbari.annosaurus.repository.jpa.entity.{AssociationEntity, CachedAncillaryDatumEntity, CachedVideoReferenceInfoEntity, ImageReferenceEntity, ImagedMomentEntity, IndexEntity, ObservationEntity}
+import org.mbari.annosaurus.repository.jpa.entity.{
+    AssociationEntity,
+    CachedAncillaryDatumEntity,
+    CachedVideoReferenceInfoEntity,
+    ImageReferenceEntity,
+    ImagedMomentEntity,
+    IndexEntity,
+    ObservationEntity
+}
 
 import scala.jdk.CollectionConverters.*
 

--- a/it/src/main/scala/org/mbari/annosaurus/AssertUtils.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/AssertUtils.scala
@@ -16,7 +16,7 @@
 
 package org.mbari.annosaurus
 
-import org.junit.Assert._
+import org.junit.Assert.*
 
 import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
 import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
@@ -28,32 +28,29 @@ import org.mbari.annosaurus.domain.CachedVideoReferenceInfo
 import org.mbari.annosaurus.repository.jpa.entity.CachedVideoReferenceInfoEntity
 import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
 
-object AssertUtils {
+object AssertUtils:
 
     def assertSameImagedMoment(
         a: ImagedMomentEntity,
         b: ImagedMomentEntity,
         cascade: Boolean = true
-    ): Unit = {
-        if (a == null && b == null) {
+    ): Unit =
+        if a == null && b == null then {
             // do nothing
         }
-        else if (a != null && b != null) {
+        else if a != null && b != null then
             // assertEquals(a.getTimecode(), b.getTimecode())
-            if (a.getTimecode() != null && b.getTimecode() != null) {
+            if a.getTimecode() != null && b.getTimecode() != null then
                 assertEquals(a.getTimecode().toString(), b.getTimecode().toString())
-            }
-            else if (a.getTimecode() == null && b.getTimecode() == null) {
+            else if a.getTimecode() == null && b.getTimecode() == null then {
                 // do nothing
             }
-            else {
-                fail("One of the timecodes is null")
-            }
+            else fail("One of the timecodes is null")
             assertEquals(a.getElapsedTime(), b.getElapsedTime())
             assertEquals(a.getRecordedTimestamp(), b.getRecordedTimestamp())
             assertEquals(a.getVideoReferenceUuid(), b.getVideoReferenceUuid())
             assertEquals(a.getUuid(), b.getUuid())
-            if (cascade) {
+            if cascade then
                 assertEquals(a.getObservations.size, b.getObservations.size)
                 val ax = Option(a.getObservations)
                     .map(_.asScala.toSeq.sortBy(_.getUuid()))
@@ -73,82 +70,63 @@ object AssertUtils {
                 ay.zip(by).foreach(p => assertSameImageReference(p._1, p._2))
 
                 assertSameAncillaryDatum(a.getAncillaryDatum(), b.getAncillaryDatum())
-            }
-        }
-        else {
-            fail("One of the ImagedMoments is null")
-        }
-    }
+        else fail("One of the ImagedMoments is null")
 
     def assertSameObservation(
         a: ObservationEntity,
         b: ObservationEntity,
         cascade: Boolean = true
-    ): Unit = {
-        if (a == null && b == null) {
+    ): Unit =
+        if a == null && b == null then {
             // do nothing
         }
-        else if (a != null && b != null) {
+        else if a != null && b != null then
             assertEquals(a.getConcept(), b.getConcept())
             assertEquals(a.getGroup(), b.getGroup())
             assertEquals(a.getActivity(), b.getActivity())
             assertEquals(a.getDuration(), b.getDuration())
             assertEquals(a.getObserver(), b.getObserver())
             assertEquals(a.getUuid(), b.getUuid())
-            if (cascade) {
+            if cascade then
                 assertEquals(a.getAssociations().size, b.getAssociations().size)
                 val ax = a.getAssociations().asScala.toSeq.sortBy(_.getUuid)
                 val bx = b.getAssociations().asScala.toSeq.sortBy(_.getUuid)
                 ax.zip(bx).foreach(p => assertSameAssociation(p._1, p._2))
-            }
-        }
-        else {
-            fail("One of the observations is null")
-        }
+        else fail("One of the observations is null")
 
-    }
-
-    def assertSameImageReference(a: ImageReferenceEntity, b: ImageReferenceEntity): Unit = {
-        if (a == null && b == null) {
+    def assertSameImageReference(a: ImageReferenceEntity, b: ImageReferenceEntity): Unit =
+        if a == null && b == null then {
             // do nothing
         }
-        else if (a != null && b != null) {
+        else if a != null && b != null then
             assertEquals(a.getUuid, b.getUuid())
             assertEquals(a.getUrl(), b.getUrl())
             assertEquals(a.getWidth(), b.getWidth())
             assertEquals(a.getHeight(), b.getHeight())
             assertEquals(a.getDescription(), b.getDescription())
             assertEquals(a.getFormat(), b.getFormat())
-        }
-        else {
-            fail("One of the imagereferences is null")
-        }
-    }
+        else fail("One of the imagereferences is null")
 
-    def assertSameAssociation(a: AssociationEntity, b: AssociationEntity): Unit = {
-        if (a == null && b == null) {
+    def assertSameAssociation(a: AssociationEntity, b: AssociationEntity): Unit =
+        if a == null && b == null then {
             // do nothing
         }
-        else if (a != null && b != null) {
+        else if a != null && b != null then
             assertEquals(a.getUuid(), b.getUuid())
             assertEquals(a.getLinkName(), b.getLinkName())
             assertEquals(a.getToConcept(), b.getToConcept())
             assertEquals(a.getLinkValue(), b.getLinkValue())
             assertEquals(a.getMimeType(), b.getMimeType())
-        }
-        else {
-            fail("One of the associations is null")
-        }
-    }
+        else fail("One of the associations is null")
 
     def assertSameAncillaryDatum(
         a: CachedAncillaryDatumEntity,
         b: CachedAncillaryDatumEntity
-    ): Unit = {
-        if (a == null && b == null) {
+    ): Unit =
+        if a == null && b == null then {
             // do nothing
         }
-        else if (a != null && b != null) {
+        else if a != null && b != null then
             assertEquals(a.getUuid(), b.getUuid())
             assertEquals(a.getX(), b.getX())
             assertEquals(a.getY(), b.getY())
@@ -164,50 +142,37 @@ object AssertUtils {
             assertEquals(a.getOxygenMlL(), b.getOxygenMlL())
             assertEquals(a.getSalinity(), b.getSalinity())
             assertEquals(a.getTemperatureCelsius(), b.getTemperatureCelsius())
-        }
-        else {
-            fail("One of the ancillarydata is null")
-        }
-    }
+        else fail("One of the ancillarydata is null")
 
     def assertSameVideoReferenceInfo(
         a: CachedVideoReferenceInfoEntity,
         b: CachedVideoReferenceInfoEntity
-    ): Unit = {
-        if (a == null && b == null) {
+    ): Unit =
+        if a == null && b == null then {
             // do nothing
         }
-        else if (a != null && b != null) {
+        else if a != null && b != null then
             assertEquals(a.getUuid(), b.getUuid())
             assertEquals(a.getVideoReferenceUuid(), b.getVideoReferenceUuid())
             assertEquals(a.getMissionContact(), b.getMissionContact())
             assertEquals(a.getMissionId(), b.getMissionId())
             assertEquals(a.getPlatformName(), b.getPlatformName())
-        }
-    }
 
     def assertSameIndex(
         a: IndexEntity,
         b: IndexEntity
-    ): Unit = {
-        if (a == null && b == null) {
+    ): Unit =
+        if a == null && b == null then {
             // do nothing
         }
-        else if (a != null && b != null) {
+        else if a != null && b != null then
             assertEquals(a.getUuid(), b.getUuid())
             assertEquals(a.getVideoReferenceUuid(), b.getVideoReferenceUuid())
             assertEquals(a.getElapsedTime(), b.getElapsedTime())
             assertEquals(a.getRecordedTimestamp(), b.getRecordedTimestamp())
-            if (a.getTimecode() != null && b.getTimecode() != null) {
+            if a.getTimecode() != null && b.getTimecode() != null then
                 assertEquals(a.getTimecode().toString(), b.getTimecode().toString())
-            }
-            else if (a.getTimecode() == null && b.getTimecode() == null) {
+            else if a.getTimecode() == null && b.getTimecode() == null then {
                 // do nothing
             }
-            else {
-                fail("One of the timecodes is null")
-            }
-        }
-    }
-
-}
+            else fail("One of the timecodes is null")

--- a/it/src/main/scala/org/mbari/annosaurus/AssertUtils.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/AssertUtils.scala
@@ -17,16 +17,9 @@
 package org.mbari.annosaurus
 
 import org.junit.Assert.*
+import org.mbari.annosaurus.repository.jpa.entity.{AssociationEntity, CachedAncillaryDatumEntity, CachedVideoReferenceInfoEntity, ImageReferenceEntity, ImagedMomentEntity, IndexEntity, ObservationEntity}
 
-import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
-import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
-import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
-import org.mbari.annosaurus.repository.jpa.entity.AssociationEntity
-import org.mbari.annosaurus.repository.jpa.entity.CachedAncillaryDatumEntity
 import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.domain.CachedVideoReferenceInfo
-import org.mbari.annosaurus.repository.jpa.entity.CachedVideoReferenceInfoEntity
-import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
 
 object AssertUtils:
 

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/AnnotationControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/AnnotationControllerSuite.scala
@@ -18,7 +18,6 @@ package org.mbari.annosaurus.controllers
 
 import org.mbari.annosaurus.AssertUtils
 import org.mbari.annosaurus.domain.{Annotation, ConcurrentRequest, MultiRequest}
-import org.mbari.annosaurus.etc.circe.CirceCodecs.*
 import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, ImagedMomentDAOImpl, JPADAOFactory}
 import org.mbari.vcr4j.time.Timecode

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/AnnotationControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/AnnotationControllerSuite.scala
@@ -37,7 +37,7 @@ import java.util.UUID
 import scala.io.Source
 import scala.util.{Failure, Success, Using}
 
-trait AnnotationControllerSuite extends BaseDAOSuite {
+trait AnnotationControllerSuite extends BaseDAOSuite:
     given JPADAOFactory    = daoFactory
     given ExecutionContext = ExecutionContext.global
     lazy val controller    = AnnotationController(daoFactory)
@@ -401,5 +401,3 @@ trait AnnotationControllerSuite extends BaseDAOSuite {
         assert(imOpt.isEmpty)
         imDao.close()
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/AnnotationControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/AnnotationControllerSuite.scala
@@ -190,8 +190,8 @@ trait AnnotationControllerSuite extends BaseDAOSuite {
     }
 
     test("create(Annotation)") {
-        val im = TestUtils.build(1, 1).head
-        val expected = Annotation.from(im.getObservations.asScala.head, true)
+        val im        = TestUtils.build(1, 1).head
+        val expected  = Annotation.from(im.getObservations.asScala.head, true)
         val obtained  = exec(controller.create(expected)).head
         assert(obtained.observationUuid.isDefined)
         assert(obtained.imagedMomentUuid.isDefined)

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/AnnotationControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/AnnotationControllerSuite.scala
@@ -16,26 +16,19 @@
 
 package org.mbari.annosaurus.controllers
 
-import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, ImagedMomentDAOImpl, JPADAOFactory}
-
-import scala.concurrent.ExecutionContext
 import org.mbari.annosaurus.AssertUtils
-import org.mbari.annosaurus.domain.Annotation
-
-import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.etc.jdk.Logging.given
-import org.mbari.annosaurus.domain.ConcurrentRequest
+import org.mbari.annosaurus.domain.{Annotation, ConcurrentRequest, MultiRequest}
+import org.mbari.annosaurus.etc.circe.CirceCodecs.*
 import org.mbari.annosaurus.etc.sdk.Futures.*
-
-import java.time.{Duration, Instant}
-import org.mbari.annosaurus.domain.MultiRequest
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
+import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, ImagedMomentDAOImpl, JPADAOFactory}
 import org.mbari.vcr4j.time.Timecode
 
-import java.nio.file.Files
+import java.time.{Duration, Instant}
 import java.util.UUID
+import scala.concurrent.ExecutionContext
 import scala.io.Source
-import scala.util.{Failure, Success, Using}
+import scala.jdk.CollectionConverters.*
+import scala.util.Using
 
 trait AnnotationControllerSuite extends BaseDAOSuite:
     given JPADAOFactory    = daoFactory

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/AssociationControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/AssociationControllerSuite.scala
@@ -17,15 +17,10 @@
 package org.mbari.annosaurus.controllers
 
 import org.mbari.annosaurus.AssertUtils
-import org.mbari.annosaurus.repository.jpa.BaseDAOSuite
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import org.mbari.annosaurus.domain.{Association, ConceptAssociationRequest}
+import org.mbari.annosaurus.repository.jpa.{AssociationDAOImpl, BaseDAOSuite, JPADAOFactory}
 
-import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.domain.Association
-import junit.framework.Test
-import org.mbari.annosaurus.repository.jpa.AssociationDAOImpl
-import org.mbari.annosaurus.domain.ConceptAssociationRequest
 
 trait AssociationControllerSuite extends BaseDAOSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/AssociationControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/AssociationControllerSuite.scala
@@ -27,7 +27,7 @@ import junit.framework.Test
 import org.mbari.annosaurus.repository.jpa.AssociationDAOImpl
 import org.mbari.annosaurus.domain.ConceptAssociationRequest
 
-trait AssociationControllerSuite extends BaseDAOSuite {
+trait AssociationControllerSuite extends BaseDAOSuite:
 
     implicit val df: JPADAOFactory = daoFactory
 //    override implicit val ec: ExecutionContext = ExecutionContext.global
@@ -237,4 +237,3 @@ trait AssociationControllerSuite extends BaseDAOSuite {
         val ass0      = opt.get
         assertEquals(ass0.toConcept, toConcept)
     }
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumControllerSuite.scala
@@ -17,10 +17,9 @@
 package org.mbari.annosaurus.controllers
 
 import org.mbari.annosaurus.domain.CachedAncillaryDatum
-import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.jdk.Numbers.*
-import java.sql.Timestamp
+import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
+
 import java.time.{Duration, Instant}
 import scala.util.Random
 

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/CachedAncillaryDatumControllerSuite.scala
@@ -24,7 +24,7 @@ import java.sql.Timestamp
 import java.time.{Duration, Instant}
 import scala.util.Random
 
-trait CachedAncillaryDatumControllerSuite extends BaseDAOSuite {
+trait CachedAncillaryDatumControllerSuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -196,12 +196,12 @@ trait CachedAncillaryDatumControllerSuite extends BaseDAOSuite {
         // test create
         val s0 = TestUtils
             .create(4, 1, 1, 1, false)
-            .map(x => {
+            .map(x =>
                 val ad = TestUtils.randomData()
                 ad.setDepthMeters(1000)
                 x.setAncillaryDatum(ad)
                 CachedAncillaryDatum.from(ad, true)
-            })
+            )
         val a0 = exec(controller.bulkCreateOrUpdate(s0))
         for s <- s0
         do
@@ -223,11 +223,11 @@ trait CachedAncillaryDatumControllerSuite extends BaseDAOSuite {
         // test update
         val s0 = TestUtils
             .create(4, 1, 1, 1, true)
-            .map(x => {
+            .map(x =>
                 val ad = x.getAncillaryDatum
                 ad.setDepthMeters(1000)
                 CachedAncillaryDatum.from(ad, true)
-            })
+            )
         val a0 = exec(controller.bulkCreateOrUpdate(s0))
         for s <- s0
         do
@@ -247,18 +247,18 @@ trait CachedAncillaryDatumControllerSuite extends BaseDAOSuite {
     test("bulkCreateOrUpdate (mixed create/update") {
         val s0 = TestUtils
             .create(4, 1, 1, 1, true)
-            .map(x => {
+            .map(x =>
                 val ad = x.getAncillaryDatum
                 ad.setDepthMeters(1000)
                 CachedAncillaryDatum.from(ad, true)
-            }) ++ TestUtils
+            ) ++ TestUtils
             .create(4, 1, 1, 1, false)
-            .map(x => {
+            .map(x =>
                 val ad = TestUtils.randomData()
                 ad.setDepthMeters(1000)
                 x.setAncillaryDatum(ad)
                 CachedAncillaryDatum.from(ad, true)
-            })
+            )
 
         val a0 = exec(controller.bulkCreateOrUpdate(s0))
         for s <- s0
@@ -281,13 +281,13 @@ trait CachedAncillaryDatumControllerSuite extends BaseDAOSuite {
         val minEpochMillis = xs.map(_.getRecordedTimestamp.toEpochMilli).min
         val s0             = xs
             .zipWithIndex
-            .map((im, idx) => {
+            .map((im, idx) =>
                 val ts = Instant
                     .ofEpochMilli(im.getRecordedTimestamp.toEpochMilli + Random.nextInt(14000))
                 CachedAncillaryDatum
                     .from(TestUtils.randomData())
                     .copy(recordedTimestamp = Some(ts), depthMeters = Some(1000))
-            })
+            )
         val ys             = exec(controller.merge(s0, xs.head.getVideoReferenceUuid, Duration.ofSeconds(15)))
         assertEquals(ys.size, xs.size)
         for x <- xs
@@ -334,5 +334,3 @@ trait CachedAncillaryDatumControllerSuite extends BaseDAOSuite {
                 assert(obtained.salinity.isEmpty)
                 assert(obtained.temperatureCelsius.isEmpty)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/CachedVideoReferenceInfoControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/CachedVideoReferenceInfoControllerSuite.scala
@@ -21,14 +21,14 @@ import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
 
 import scala.concurrent.ExecutionContext
 
-trait CachedVideoReferenceInfoControllerSuite extends BaseDAOSuite {
+trait CachedVideoReferenceInfoControllerSuite extends BaseDAOSuite:
 
     given JPADAOFactory    = daoFactory
     given ExecutionContext = ExecutionContext.global
 
     private lazy val controller = new CachedVideoReferenceInfoController(daoFactory)
 
-    private def createOne(): CachedVideoReferenceInfo = {
+    private def createOne(): CachedVideoReferenceInfo =
         val vi = TestUtils.randomVideoReferenceInfo()
         exec(
             controller.create(
@@ -38,7 +38,6 @@ trait CachedVideoReferenceInfoControllerSuite extends BaseDAOSuite {
                 Option(vi.getMissionContact)
             )
         )
-    }
 
     test("findByVideoReferenceUUID") {
         val existing = createOne()
@@ -67,19 +66,19 @@ trait CachedVideoReferenceInfoControllerSuite extends BaseDAOSuite {
     test("findAllMissionContacts") {
         val xs       = (0 until 5).map(_ => createOne()).map(_.missionContact.get).toSet
         val obtained = exec(controller.findAllMissionContacts()).toSet
-        for (x <- xs) assert(obtained.contains(x))
+        for x <- xs do assert(obtained.contains(x))
     }
 
     test("findAllPlatformNames") {
         val xs       = (0 until 5).map(_ => createOne()).map(_.platformName.get).toSet
         val obtained = exec(controller.findAllPlatformNames()).toSet
-        for (x <- xs) assert(obtained.contains(x))
+        for x <- xs do assert(obtained.contains(x))
     }
 
     test("findAllMissionIds") {
         val xs       = (0 until 5).map(_ => createOne()).map(_.missionId.get).toSet
         val obtained = exec(controller.findAllMissionIds()).toSet
-        for (x <- xs) assert(obtained.contains(x))
+        for x <- xs do assert(obtained.contains(x))
     }
 
     test("create") {
@@ -132,5 +131,3 @@ trait CachedVideoReferenceInfoControllerSuite extends BaseDAOSuite {
         val obtained = exec(controller.findByUUID(existing.uuid))
         assertEquals(obtained, Option(existing))
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataControllerSuite.scala
@@ -17,18 +17,14 @@
 package org.mbari.annosaurus.controllers
 
 import org.mbari.annosaurus.domain.CachedAncillaryDatum
-import org.mbari.annosaurus.repository.jpa.{
-    BaseDAOSuite,
-    CachedAncillaryDatumDAOImpl,
-    JPADAOFactory
-}
+import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, CachedAncillaryDatumDAOImpl, JPADAOFactory}
 import org.mbari.annosaurus.etc.jdk.Logging.given
 import org.mbari.annosaurus.repository.jpa.extensions.runTransaction
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 
 import scala.concurrent.ExecutionContext
 
-trait FastAncillaryDataControllerSuite extends BaseDAOSuite {
+trait FastAncillaryDataControllerSuite extends BaseDAOSuite:
 
     given JPADAOFactory    = daoFactory
     given ExecutionContext = ExecutionContext.global
@@ -38,7 +34,7 @@ trait FastAncillaryDataControllerSuite extends BaseDAOSuite {
 
     override def afterAll(): Unit = daoFactory.afterAll()
 
-    private def runTransaction[A](fn: FastAncillaryDataController => A): A = {
+    private def runTransaction[A](fn: FastAncillaryDataController => A): A =
         val dao        = daoFactory.newCachedAncillaryDatumDAO()
         val em         = dao.entityManager
         val controller = FastAncillaryDataController(em)
@@ -47,15 +43,14 @@ trait FastAncillaryDataControllerSuite extends BaseDAOSuite {
         em.getTransaction.commit()
         dao.close()
         result
-    }
 
     test("createOrUpdate") {
         val xs    = TestUtils.create(2, includeData = true) ++ TestUtils.create(2)
         val pairs = xs
-            .map(im => {
+            .map(im =>
                 val ad = TestUtils.randomData()
                 im -> CachedAncillaryDatum.from(ad).copy(imagedMomentUuid = Option(im.getUuid))
-            })
+            )
             .toMap
 
         // Make sure we set the im uuid correctly
@@ -129,5 +124,3 @@ trait FastAncillaryDataControllerSuite extends BaseDAOSuite {
                 assertEquals(obtained.salinity, dto.salinity)
 
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/FastAncillaryDataControllerSuite.scala
@@ -17,10 +17,8 @@
 package org.mbari.annosaurus.controllers
 
 import org.mbari.annosaurus.domain.CachedAncillaryDatum
-import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, CachedAncillaryDatumDAOImpl, JPADAOFactory}
-import org.mbari.annosaurus.etc.jdk.Logging.given
-import org.mbari.annosaurus.repository.jpa.extensions.runTransaction
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
+import org.mbari.annosaurus.etc.circe.CirceCodecs.*
+import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
 
 import scala.concurrent.ExecutionContext
 

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/ImageControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/ImageControllerSuite.scala
@@ -23,7 +23,7 @@ import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 
 import scala.jdk.CollectionConverters.*
 
-trait ImageControllerSuite extends BaseDAOSuite {
+trait ImageControllerSuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -78,8 +78,8 @@ trait ImageControllerSuite extends BaseDAOSuite {
         val images       = exec(controller.bulkCreate(imageCreates))
         assertEquals(images.size, seed.size)
 
-        for (i <- imageCreates) {
-            exec(controller.findByURL(i.url)) match {
+        for i <- imageCreates do
+            exec(controller.findByURL(i.url)) match
                 case Some(im) =>
                     assertEquals(im.videoReferenceUuid, i.video_reference_uuid)
                     assertEquals(im.url.orNull, i.url)
@@ -91,8 +91,6 @@ trait ImageControllerSuite extends BaseDAOSuite {
                     assertEquals(im.heightPixels, i.height_pixels)
                     assertEquals(im.description, i.description)
                 case None     => fail(s"Could not find ImageReference with url=${i.url}")
-            }
-        }
 
         // Try to insert duplicates. None should be created
         val images2 = exec(controller.bulkCreate(imageCreates))
@@ -186,5 +184,3 @@ trait ImageControllerSuite extends BaseDAOSuite {
         val opt = exec(controller.findByUUID(i.getUuid))
         assert(opt.isEmpty)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/ImageControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/ImageControllerSuite.scala
@@ -16,12 +16,8 @@
 
 package org.mbari.annosaurus.controllers
 
-import org.mbari.annosaurus.AssertUtils
 import org.mbari.annosaurus.domain.{Image, ImageCreateSC}
 import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-
-import scala.jdk.CollectionConverters.*
 
 trait ImageControllerSuite extends BaseDAOSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/ImageReferenceControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/ImageReferenceControllerSuite.scala
@@ -21,7 +21,7 @@ import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
 
 import scala.jdk.CollectionConverters.*
 
-trait ImageReferenceControllerSuite extends BaseDAOSuite {
+trait ImageReferenceControllerSuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -116,5 +116,3 @@ trait ImageReferenceControllerSuite extends BaseDAOSuite {
         assertEquals(ir0.getWidth.intValue(), ir1.get.widthPixels.orNull)
         assertEquals(ir0.getFormat, ir1.get.format.orNull)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentContollerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentContollerSuite.scala
@@ -16,24 +16,17 @@
 
 package org.mbari.annosaurus.controllers
 
-import org.mbari.annosaurus.repository.jpa.BaseDAOSuite
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-
-import scala.concurrent.ExecutionContext
-import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.etc.jdk.Logging.given
 import org.mbari.annosaurus.AssertUtils
-
-import java.time.Duration
 import org.mbari.annosaurus.domain.WindowRequest
-
-import java.time.Instant
-import java.util.UUID
-import org.mbari.annosaurus.repository.jpa.ImagedMomentDAOImpl
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
+import org.mbari.annosaurus.etc.jdk.Logging.given
 import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
+import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, ImagedMomentDAOImpl, JPADAOFactory}
 
 import java.net.URI
+import java.time.{Duration, Instant}
+import java.util.UUID
+import scala.concurrent.ExecutionContext
 import scala.util.Random
 
 trait ImagedMomentContollerSuite extends BaseDAOSuite:

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentContollerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentContollerSuite.scala
@@ -19,7 +19,7 @@ package org.mbari.annosaurus.controllers
 import org.mbari.annosaurus.AssertUtils
 import org.mbari.annosaurus.domain.WindowRequest
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
 import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, ImagedMomentDAOImpl, JPADAOFactory}
 

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentContollerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/ImagedMomentContollerSuite.scala
@@ -36,7 +36,7 @@ import org.mbari.annosaurus.repository.jpa.entity.ImagedMomentEntity
 import java.net.URI
 import scala.util.Random
 
-trait ImagedMomentContollerSuite extends BaseDAOSuite {
+trait ImagedMomentContollerSuite extends BaseDAOSuite:
 
     given JPADAOFactory    = daoFactory
     given ExecutionContext = ExecutionContext.global
@@ -303,7 +303,7 @@ trait ImagedMomentContollerSuite extends BaseDAOSuite {
         val videoReferenceUuid = UUID.randomUUID()
         val url                = URI.create("http://www.mbari.org/foo/image.png").toURL
         intercept[Exception] {
-            for (i <- 0 until 2) {
+            for i <- 0 until 2 do
                 val source         = new ImagedMomentEntity(
                     videoReferenceUuid,
                     Instant.now().plus(Duration.ofSeconds(Random.nextInt())),
@@ -314,7 +314,6 @@ trait ImagedMomentContollerSuite extends BaseDAOSuite {
                 imageReference.setUrl(url)
                 source.addImageReference(imageReference)
                 exec(controller.create(Seq(source)))
-            }
         }
     }
 
@@ -416,5 +415,3 @@ trait ImagedMomentContollerSuite extends BaseDAOSuite {
         val im2 = run(() => ImagedMomentController.findOrCreateImagedMoment(dao, im0))
         AssertUtils.assertSameImagedMoment(im2, im1)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/IndexControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/IndexControllerSuite.scala
@@ -21,7 +21,7 @@ import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
 
 import java.time.{Duration, Instant}
 
-trait IndexControllerSuite extends BaseDAOSuite {
+trait IndexControllerSuite extends BaseDAOSuite:
 
     given JPADAOFactory         = daoFactory
     private lazy val controller = new IndexController(daoFactory)
@@ -87,5 +87,3 @@ trait IndexControllerSuite extends BaseDAOSuite {
         assertEquals(obtained.recordedTimestamp.orNull, im.getRecordedTimestamp)
 
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/ObservationControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/ObservationControllerSuite.scala
@@ -16,13 +16,12 @@
 
 package org.mbari.annosaurus.controllers
 
-import org.mbari.annosaurus.repository.jpa.BaseDAOSuite
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import scala.concurrent.ExecutionContext
 import org.mbari.annosaurus.AssertUtils
-import scala.jdk.CollectionConverters.*
-import junit.framework.Assert
+import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
+
 import java.time.Duration
+import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters.*
 
 trait ObservationControllerSuite extends BaseDAOSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/ObservationControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/ObservationControllerSuite.scala
@@ -238,7 +238,7 @@ trait ObservationControllerSuite extends BaseDAOSuite:
         val xs     = TestUtils.create(2, 2)
         val n      = xs.flatMap(im => im.getObservations().asScala).size
         val counts = exec(controller.countAllGroupByVideoReferenceUuid())
-        assert(counts.size >= 2)
+        assertEquals(counts.size, 1)
         val uuids  = xs.map(_.getVideoReferenceUuid())
         for uuid <- uuids
         do

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/ObservationControllerSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/ObservationControllerSuite.scala
@@ -24,7 +24,7 @@ import scala.jdk.CollectionConverters.*
 import junit.framework.Assert
 import java.time.Duration
 
-trait ObservationControllerSuite extends BaseDAOSuite {
+trait ObservationControllerSuite extends BaseDAOSuite:
 
     given JPADAOFactory    = daoFactory
     given ExecutionContext = ExecutionContext.global
@@ -109,7 +109,7 @@ trait ObservationControllerSuite extends BaseDAOSuite {
     test("findAllActivities") {
         val xs           = TestUtils.create(1, 9)
         val expected     = xs
-            .flatMap(im => im.getObservations().asScala.map(_.getActivity()))
+            .flatMap(im => im.getObservations.asScala.map(_.getActivity()))
             .toSet
             .filter(_ != null)
         val obtained     = exec(controller.findAllActivities)
@@ -260,5 +260,3 @@ trait ObservationControllerSuite extends BaseDAOSuite {
         o0.setConcept(newConcept)
         AssertUtils.assertSameObservation(o0, obtained.get.toEntity)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtils.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtils.scala
@@ -30,7 +30,7 @@ import java.sql.Connection
 import java.time.{Duration, Instant}
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-import scala.concurrent.{Await, ExecutionContext, duration}
+import scala.concurrent.{duration, Await, ExecutionContext}
 import scala.util.Random
 
 object TestUtils:

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtils.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtils.scala
@@ -16,19 +16,13 @@
 
 package org.mbari.annosaurus.controllers
 
+import org.mbari.annosaurus.domain.Annotation
+import org.mbari.annosaurus.etc.jdk.Logging.given
 import org.mbari.annosaurus.etc.jdk.Strings
-import org.mbari.annosaurus.repository.jpa.entity.{
-    AssociationEntity,
-    CachedAncillaryDatumEntity,
-    ImageReferenceEntity,
-    ImagedMomentEntity,
-    ObservationEntity
-}
-import org.mbari.scilube3.ocean.Ocean
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.repository.jpa.entity.*
+import org.mbari.scilube3.ocean.Ocean
 import org.mbari.vcr4j.time.{FrameRates, Timecode}
-import org.mbari.annosaurus.etc.jdk.Logging.given
 
 import java.net.URI
 import java.security.MessageDigest
@@ -36,12 +30,8 @@ import java.sql.Connection
 import java.time.{Duration, Instant}
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-import scala.concurrent.duration
+import scala.concurrent.{Await, ExecutionContext, duration}
 import scala.util.Random
-import scala.concurrent.ExecutionContext
-import java.sql.Timestamp
-import scala.concurrent.Await
-import org.mbari.annosaurus.domain.Annotation
 
 object TestUtils:
 

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtils.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtils.scala
@@ -17,7 +17,7 @@
 package org.mbari.annosaurus.controllers
 
 import org.mbari.annosaurus.domain.Annotation
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 import org.mbari.annosaurus.etc.jdk.Strings
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.repository.jpa.entity.*

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtils.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtils.scala
@@ -26,7 +26,7 @@ import org.mbari.annosaurus.repository.jpa.entity.{
 }
 import org.mbari.scilube3.ocean.Ocean
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.repository.jpa.entity._
+import org.mbari.annosaurus.repository.jpa.entity.*
 import org.mbari.vcr4j.time.{FrameRates, Timecode}
 import org.mbari.annosaurus.etc.jdk.Logging.given
 
@@ -43,7 +43,7 @@ import java.sql.Timestamp
 import scala.concurrent.Await
 import org.mbari.annosaurus.domain.Annotation
 
-object TestUtils {
+object TestUtils:
 
     val Timeout            = duration.Duration(3, TimeUnit.SECONDS)
     val Digest             = MessageDigest.getInstance("SHA-512")
@@ -52,16 +52,15 @@ object TestUtils {
 
     private val log = System.getLogger(getClass.getName)
 
-    def runDdl(ddl: String, connection: Connection): Unit = {
+    def runDdl(ddl: String, connection: Connection): Unit =
         val statement = connection.createStatement();
         ddl
             .split(";")
-            .foreach(sql => {
+            .foreach(sql =>
                 log.atWarn.log(s"Running:\n$sql")
                 statement.execute(sql)
-            })
+            )
         statement.close()
-    }
 
     def build(
         nImagedMoments: Int = 1,
@@ -69,7 +68,7 @@ object TestUtils {
         nAssociations: Int = 0,
         nImageReferences: Int = 0,
         includeData: Boolean = false
-    ): Seq[ImagedMomentEntity] = {
+    ): Seq[ImagedMomentEntity] =
         val startDate          = Instant.now()
         val videoReferenceUuid = UUID.randomUUID()
         for (_ <- 0 until nImagedMoments)
@@ -81,17 +80,15 @@ object TestUtils {
                 videoReferenceUuid,
                 startDate
             )
-    }
 
     def create(
         entities: Seq[ImagedMomentEntity]
-    )(using daoFactory: JPADAOFactory, ec: ExecutionContext): Seq[ImagedMomentEntity] = {
+    )(using daoFactory: JPADAOFactory, ec: ExecutionContext): Seq[ImagedMomentEntity] =
         log.atDebug.log(s"Creating ${entities.size} ImagedMoments: $entities")
         val dao = daoFactory.newImagedMomentDAO()
         Await.ready(dao.runTransaction(d => entities.foreach(x => d.create(x))), Timeout)
         dao.close()
         entities
-    }
 
     def create(
         nImagedMoments: Int = 1,
@@ -99,14 +96,13 @@ object TestUtils {
         nAssociations: Int = 0,
         nImageReferences: Int = 0,
         includeData: Boolean = false
-    )(using daoFactory: JPADAOFactory, ec: ExecutionContext): Seq[ImagedMomentEntity] = {
+    )(using daoFactory: JPADAOFactory, ec: ExecutionContext): Seq[ImagedMomentEntity] =
         val xs  = build(nImagedMoments, nObservations, nAssociations, nImageReferences, includeData)
         log.atDebug.log(s"Creating ${xs.size} ImagedMoments: $xs")
         val dao = daoFactory.newImagedMomentDAO()
         Await.ready(dao.runTransaction(d => xs.foreach(x => d.create(x))), Timeout)
         dao.close()
         xs
-    }
 
     def randomImagedMoment(
         nObservations: Int = 0,
@@ -115,32 +111,29 @@ object TestUtils {
         includeData: Boolean = false,
         videoReferenceUuid: UUID = UUID.randomUUID(),
         startDate: Instant = Instant.now().minus(Duration.ofDays(30))
-    ): ImagedMomentEntity = {
+    ): ImagedMomentEntity =
         val et           = random.nextLong(2592000000L) // 30 days
         val elapsedTime  = Duration.ofMillis(et)
         val recordedDate = startDate.plusMillis(et)
         val timecode     =
-            if (random.nextBoolean())
-                Some(new Timecode(random.nextInt(10000).toDouble, FrameRates.NTSC))
+            if random.nextBoolean() then Some(new Timecode(random.nextInt(10000).toDouble, FrameRates.NTSC))
             else None
         val imagedMoment =
             ImagedMomentEntity(videoReferenceUuid, recordedDate, timecode.orNull, elapsedTime)
-        for (_ <- 0 until nObservations)
-            imagedMoment.addObservation(randomObservation(nAssociations))
-        for (_ <- 0 until nImageReferences) imagedMoment.addImageReference(randomImageReference())
-        if (includeData) imagedMoment.setAncillaryDatum(randomData())
+        for _ <- 0 until nObservations do imagedMoment.addObservation(randomObservation(nAssociations))
+        for _ <- 0 until nImageReferences do imagedMoment.addImageReference(randomImageReference())
+        if includeData then imagedMoment.setAncillaryDatum(randomData())
         imagedMoment
-    }
 
-    def randomObservation(nAssociations: Int = 0): ObservationEntity = {
+    def randomObservation(nAssociations: Int = 0): ObservationEntity =
         //        val obs = obsDao.newPersistentObject(Strings.random(conceptLength), Strings.random(10), Instant.now(), Some(Strings.random(6)))
         val concept         = Strings.random(random.nextInt(128))
         val duration        =
-            if (random.nextBoolean()) Some(Duration.ofMillis(random.nextInt(5000))) else None
+            if random.nextBoolean() then Some(Duration.ofMillis(random.nextInt(5000))) else None
         val observationDate = Instant.now()
         val observer        = Some(Strings.random(32))
-        val group           = if (random.nextBoolean()) Some(Strings.random(32)) else None
-        val activity        = if (random.nextBoolean()) Some(Strings.random(32)) else None
+        val group           = if random.nextBoolean() then Some(Strings.random(32)) else None
+        val activity        = if random.nextBoolean() then Some(Strings.random(32)) else None
         val obs             = ObservationEntity(
             concept,
             duration.orNull,
@@ -149,21 +142,17 @@ object TestUtils {
             group.orNull,
             activity.orNull
         )
-        for (_ <- 0 until nAssociations) {
-            obs.addAssociation(randomAssociation())
-        }
+        for _ <- 0 until nAssociations do obs.addAssociation(randomAssociation())
         obs
-    }
 
-    def randomAssociation(): AssociationEntity = {
+    def randomAssociation(): AssociationEntity =
         val linkName  = Strings.random(random.nextInt(30) + 2)
         val linkValue = Strings.random(random.nextInt(254) + 2)
         val toConcept = Strings.random(random.nextInt(30) + 2)
         val mimeType  = Strings.random(random.nextInt(12))
         AssociationEntity(linkName, toConcept, linkValue, mimeType)
-    }
 
-    def randomImageReference(): ImageReferenceEntity = {
+    def randomImageReference(): ImageReferenceEntity =
         val url         = URI
             .create(s"http://www.foo.bar/${Strings.random(10)}/image_${random.nextInt()}.png")
             .toURL
@@ -171,9 +160,8 @@ object TestUtils {
         val width       = random.nextInt(1440) + 480
         val height      = math.round(width * 0.5625).toInt
         new ImageReferenceEntity(url, width, height, "image/png", description)
-    }
 
-    def randomData(): CachedAncillaryDatumEntity = {
+    def randomData(): CachedAncillaryDatumEntity =
         val lat      = (random.nextInt(18000) / 100d) - 90.0
         val lon      = (random.nextInt(36000) / 100d) - 180.0
         val pressure = random.nextInt(20000) / 10d
@@ -210,49 +198,37 @@ object TestUtils {
         datum.setPsi(psi)
         datum.setLightTransmission(trans)
         datum
-    }
 
     def randomVideoReferenceInfo(
         videoReferenceUuid: UUID = UUID.randomUUID()
-    ): CachedVideoReferenceInfoEntity = {
-
+    ): CachedVideoReferenceInfoEntity =
         CachedVideoReferenceInfoEntity(
             videoReferenceUuid,
             "p-" + Strings.random(10),
             "missionId" + Strings.random(10),
             "missionContact" + Strings.random(10)
         )
-    }
 
-    def stripLastUpdated(a: Annotation): Annotation = {
+    def stripLastUpdated(a: Annotation): Annotation =
         a.copy(
             lastUpdated = None,
             associations = a.associations.map(_.copy(lastUpdated = None)),
             imageReferences = a.imageReferences.map(_.copy(lastUpdated = None)),
             ancillaryData = a.ancillaryData.map(_.copy(lastUpdated = None))
         )
-    }
 
-    def addRandomUuids(imagedMomentEntity: ImagedMomentEntity): ImagedMomentEntity = {
+    def addRandomUuids(imagedMomentEntity: ImagedMomentEntity): ImagedMomentEntity =
         imagedMomentEntity.setUuid(UUID.randomUUID())
-        if (imagedMomentEntity.getImageReferences() != null) {
+        if imagedMomentEntity.getImageReferences() != null then
             imagedMomentEntity.getImageReferences().forEach(img => img.setUuid(UUID.randomUUID()))
-        }
-        if (imagedMomentEntity.getAncillaryDatum() != null) {
+        if imagedMomentEntity.getAncillaryDatum() != null then
             imagedMomentEntity.getAncillaryDatum().setUuid(UUID.randomUUID())
-        }
-        if (imagedMomentEntity.getObservations() != null) {
+        if imagedMomentEntity.getObservations() != null then
             imagedMomentEntity
                 .getObservations()
-                .forEach(obs => {
+                .forEach(obs =>
                     obs.setUuid(UUID.randomUUID())
-                    if (obs.getAssociations() != null) {
+                    if obs.getAssociations() != null then
                         obs.getAssociations().forEach(assoc => assoc.setUuid(UUID.randomUUID()))
-                    }
-                })
-        }
+                )
         imagedMomentEntity
-
-    }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtilsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtilsSuite.scala
@@ -24,7 +24,7 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.jdk.CollectionConverters.*
 import org.mbari.annosaurus.repository.jpa.BaseDAOSuite
 
-trait TestUtilsSuite extends BaseDAOSuite {
+trait TestUtilsSuite extends BaseDAOSuite:
 
     val timeout = scala.concurrent.duration.Duration(10, TimeUnit.SECONDS)
 
@@ -87,5 +87,3 @@ trait TestUtilsSuite extends BaseDAOSuite {
         dao.close()
 
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtilsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/controllers/TestUtilsSuite.scala
@@ -17,12 +17,11 @@
 package org.mbari.annosaurus.controllers
 
 import org.mbari.annosaurus.AssertUtils
-import org.mbari.annosaurus.repository.jpa.TestDAOFactory
+import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, TestDAOFactory}
 
 import java.util.concurrent.TimeUnit
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.Await
 import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.repository.jpa.BaseDAOSuite
 
 trait TestUtilsSuite extends BaseDAOSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpointsSuite.scala
@@ -72,16 +72,10 @@ trait AnalysisEndpointsSuite extends EndpointsSuite:
 
     // TODO both the depth and time histogram logic needs to be reworked. They can give incorrect results
     test("timeHistogram".flaky) {
-        val xs    = TestUtils.build(10, 10, includeData = true)
-        val start = Instant.parse("1888-08-01T00:00:00Z")
-        for i <- xs.indices
-        do xs(i).setRecordedTimestamp(start.plusSeconds(i * 60 * 60))
-        val dao                 = daoFactory.newImagedMomentDAO()
-        dao.runTransaction(d => xs.foreach(d.create))
-        val minTime             = xs.map(_.getRecordedTimestamp).min
-        val maxTime             = xs.map(_.getRecordedTimestamp).max
-        val expected            =
-            xs.filter(_.getRecordedTimestamp != null).flatMap(_.getObservations.asScala).size
+        val xs = TestUtils.create(5, 5, includeData = true)
+        val minTime = xs.map(_.getRecordedTimestamp).min
+        val maxTime = xs.map(_.getRecordedTimestamp).max
+        val expected = xs.flatMap(_.getObservations.asScala).size
         val videoReferenceUuids = xs.map(_.getVideoReferenceUuid).distinct
         val qcr                 = QueryConstraints(
             videoReferenceUuids = Seq(xs.head.getVideoReferenceUuid),
@@ -91,7 +85,7 @@ trait AnalysisEndpointsSuite extends EndpointsSuite:
 //        println(qcr.toSnakeCase.stringify)
         runPost(
             endpoints.timeHistogramImpl,
-            s"http://test.com/v1/histogram/time",
+            s"http://test.com/v1/histogram/time?size=1",
             qcr.toSnakeCase.stringify,
             response =>
                 assertEquals(response.code, StatusCode.Ok)

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpointsSuite.scala
@@ -18,14 +18,10 @@ package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.domain.{DepthHistogramSC, QueryConstraints, QueryConstraintsResponseSC, TimeHistogramSC}
-import sttp.tapir.*
-import sttp.client3.*
-import sttp.model.StatusCode
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import org.mbari.annosaurus.etc.sdk.Futures.join
 import org.mbari.annosaurus.repository.jdbc.AnalysisRepository
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
+import sttp.model.StatusCode
 
 import java.time.Instant
 import scala.jdk.CollectionConverters.*

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpointsSuite.scala
@@ -17,12 +17,7 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.TestUtils
-import org.mbari.annosaurus.domain.{
-    DepthHistogramSC,
-    QueryConstraints,
-    QueryConstraintsResponseSC,
-    TimeHistogramSC
-}
+import org.mbari.annosaurus.domain.{DepthHistogramSC, QueryConstraints, QueryConstraintsResponseSC, TimeHistogramSC}
 import sttp.tapir.*
 import sttp.client3.*
 import sttp.model.StatusCode
@@ -35,7 +30,7 @@ import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import java.time.Instant
 import scala.jdk.CollectionConverters.*
 
-trait AnalysisEndpointsSuite extends EndpointsSuite {
+trait AnalysisEndpointsSuite extends EndpointsSuite:
 
     given JPADAOFactory         = daoFactory
     private lazy val repository = new AnalysisRepository(daoFactory.entityManagerFactory)
@@ -51,13 +46,12 @@ trait AnalysisEndpointsSuite extends EndpointsSuite {
             endpoints.depthHistogramImpl,
             s"http://test.com/v1/histogram/depth",
             qcr.toSnakeCase.stringify,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val qcResponse =
                     checkResponse[QueryConstraintsResponseSC[DepthHistogramSC]](response.body)
                 val obtained   = qcResponse.content.count
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -71,13 +65,12 @@ trait AnalysisEndpointsSuite extends EndpointsSuite {
             endpoints.depthHistogramImpl,
             s"http://test.com/v1/histogram/depth?size=100",
             qcr.toSnakeCase.stringify,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val qcResponse =
                     checkResponse[QueryConstraintsResponseSC[DepthHistogramSC]](response.body)
                 val obtained   = qcResponse.content.count
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -104,13 +97,12 @@ trait AnalysisEndpointsSuite extends EndpointsSuite {
             endpoints.timeHistogramImpl,
             s"http://test.com/v1/histogram/time",
             qcr.toSnakeCase.stringify,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val qcResponse =
                     checkResponse[QueryConstraintsResponseSC[TimeHistogramSC]](response.body)
                 val obtained   = qcResponse.content.count
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -124,14 +116,11 @@ trait AnalysisEndpointsSuite extends EndpointsSuite {
             endpoints.timeHistogramImpl,
             s"http://test.com/v1/histogram/time?size=100",
             qcr.toSnakeCase.stringify,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val qcResponse =
                     checkResponse[QueryConstraintsResponseSC[TimeHistogramSC]](response.body)
                 val obtained   = qcResponse.content.count
                 assertEquals(obtained, expected)
-            }
         )
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpointsSuite.scala
@@ -17,7 +17,12 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.TestUtils
-import org.mbari.annosaurus.domain.{DepthHistogramSC, QueryConstraints, QueryConstraintsResponseSC, TimeHistogramSC}
+import org.mbari.annosaurus.domain.{
+    DepthHistogramSC,
+    QueryConstraints,
+    QueryConstraintsResponseSC,
+    TimeHistogramSC
+}
 import sttp.tapir.*
 import sttp.client3.*
 import sttp.model.StatusCode
@@ -78,23 +83,22 @@ trait AnalysisEndpointsSuite extends EndpointsSuite {
 
     // TODO both the depth and time histogram logic needs to be reworked. They can give incorrect results
     test("timeHistogram".flaky) {
-        val xs = TestUtils.build(10, 10, includeData = true)
+        val xs    = TestUtils.build(10, 10, includeData = true)
         val start = Instant.parse("1888-08-01T00:00:00Z")
-        for
-            i <- xs.indices
-        do
-            xs(i).setRecordedTimestamp(start.plusSeconds(i * 60 * 60))
-        val dao = daoFactory.newImagedMomentDAO()
+        for i <- xs.indices
+        do xs(i).setRecordedTimestamp(start.plusSeconds(i * 60 * 60))
+        val dao                 = daoFactory.newImagedMomentDAO()
         dao.runTransaction(d => xs.foreach(d.create))
-        val minTime = xs.map(_.getRecordedTimestamp).min
-        val maxTime = xs.map(_.getRecordedTimestamp).max
+        val minTime             = xs.map(_.getRecordedTimestamp).min
+        val maxTime             = xs.map(_.getRecordedTimestamp).max
         val expected            =
             xs.filter(_.getRecordedTimestamp != null).flatMap(_.getObservations.asScala).size
         val videoReferenceUuids = xs.map(_.getVideoReferenceUuid).distinct
-        val qcr = QueryConstraints(
+        val qcr                 = QueryConstraints(
             videoReferenceUuids = Seq(xs.head.getVideoReferenceUuid),
             minTimestamp = Some(minTime.minusSeconds(24 * 60 * 60)),
-            maxTimestamp = Some(maxTime.plusSeconds(24 * 60 * 60)))
+            maxTimestamp = Some(maxTime.plusSeconds(24 * 60 * 60))
+        )
 //        println(qcr.toSnakeCase.stringify)
         runPost(
             endpoints.timeHistogramImpl,

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AnalysisEndpointsSuite.scala
@@ -72,10 +72,10 @@ trait AnalysisEndpointsSuite extends EndpointsSuite:
 
     // TODO both the depth and time histogram logic needs to be reworked. They can give incorrect results
     test("timeHistogram".flaky) {
-        val xs = TestUtils.create(5, 5, includeData = true)
-        val minTime = xs.map(_.getRecordedTimestamp).min
-        val maxTime = xs.map(_.getRecordedTimestamp).max
-        val expected = xs.flatMap(_.getObservations.asScala).size
+        val xs                  = TestUtils.create(5, 5, includeData = true)
+        val minTime             = xs.map(_.getRecordedTimestamp).min
+        val maxTime             = xs.map(_.getRecordedTimestamp).max
+        val expected            = xs.flatMap(_.getObservations.asScala).size
         val videoReferenceUuids = xs.map(_.getVideoReferenceUuid).distinct
         val qcr                 = QueryConstraints(
             videoReferenceUuids = Seq(xs.head.getVideoReferenceUuid),

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpointsSuite.scala
@@ -26,21 +26,20 @@ import org.mbari.annosaurus.domain.{
     MultiRequest,
     MultiRequestCountSC
 }
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
-import org.mbari.annosaurus.etc.jwt.JwtService
-import sttp.model.StatusCode
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import sttp.client3.*
+import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.etc.sdk.Reflect
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import sttp.client3.*
+import sttp.model.StatusCode
 
 import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import scala.jdk.CollectionConverters.*
 import scala.concurrent.duration.Duration as ScalaDuration
+import scala.jdk.CollectionConverters.*
 
 trait AnnotationEndpointsSuite extends EndpointsSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpointsSuite.scala
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.jdk.CollectionConverters.*
 import scala.concurrent.duration.Duration as ScalaDuration
 
-trait AnnotationEndpointsSuite extends EndpointsSuite {
+trait AnnotationEndpointsSuite extends EndpointsSuite:
 
     // If the stress test fails we wait for 10 seconds and then fail the test
     override val munitTimeout = ScalaDuration(10, TimeUnit.SECONDS)
@@ -59,12 +59,11 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAnnotationByUuidImpl,
             s"http://test.com/v1/annotations/${obs.getUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[AnnotationSC](response.body).toCamelCase
                 val expected = Annotation.from(obs).copy(lastUpdated = obtained.lastUpdated)
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -72,9 +71,7 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAnnotationByUuidImpl,
             s"http://test.com/v1/annotations/00000000-0000-0000-0000-000000000000",
-            response => {
-                assertEquals(response.code, StatusCode.NotFound)
-            }
+            response => assertEquals(response.code, StatusCode.NotFound)
         )
     }
 
@@ -85,14 +82,13 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAnnotationByImageReferenceUuidImpl,
             s"http://test.com/v1/annotations/imagereference/${ir.getUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val ys       = checkResponse[Seq[AnnotationSC]](response.body).map(_.toCamelCase)
                 assertEquals(ys.length, 1)
                 val obtained = ys.head
                 val expected = Annotation.from(obs).copy(lastUpdated = obtained.lastUpdated)
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -112,14 +108,13 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAnnotationsByVideoReferenceUuidImpl,
             s"http://test.com/v1/annotations/videoreference/${im.getVideoReferenceUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val ys       = checkResponse[Seq[AnnotationSC]](response.body).map(_.toCamelCase)
                 assertEquals(ys.length, 1)
                 val obtained = ys.head
                 val expected = Annotation.from(obs).copy(lastUpdated = obtained.lastUpdated)
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -332,12 +327,11 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
             endpoints.countByConcurrentRequestImpl,
             "http://test.com/v1/annotations/concurrent/count",
             cr.stringify,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val crc      = checkResponse[ConcurrentRequestCountSC](response.body)
                 val obtained = crc.count
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -353,12 +347,11 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
             endpoints.countByConcurrentRequestImpl,
             "http://test.com/v1/annotations/concurrent/count",
             cr.stringify,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val crc      = checkResponse[ConcurrentRequestCountSC](response.body)
                 val obtained = crc.count
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -371,12 +364,11 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
             endpoints.countByMultiRequestImpl,
             "http://test.com/v1/annotations/multi/count",
             mr.stringify,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val mrc      = checkResponse[MultiRequestCountSC](response.body)
                 val obtained = mrc.count
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -389,12 +381,11 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
             endpoints.countByMultiRequestImpl,
             "http://test.com/v1/annotations/multi/count",
             mr.stringify,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val mrc      = checkResponse[MultiRequestCountSC](response.body)
                 val obtained = mrc.count
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -519,13 +510,13 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
         val n           = 1000
         var threads     = (0 until n)
             .map(i => TestUtils.build(1, 1).head)
-            .map(im => {
+            .map(im =>
                 val obs = im.getObservations.iterator.next()
                 val a   = Annotation.from(obs)
                 a.copy(videoReferenceUuid = Some(uuid), timecode = None)
-            })
-            .map(anno => {
-                val r: Runnable = () => {
+            )
+            .map(anno =>
+                val r: Runnable = () =>
                     val response = basicRequest
                         .post(uri"http://test.com/v1/annotations")
                         .body(anno.toSnakeCase.stringify)
@@ -543,13 +534,9 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
                     )
                     assertEquals(obtained, expected)
                     count.incrementAndGet()
-                }
                 r
-            })
+            )
             .foreach(runnable => Thread.startVirtualThread(runnable))
-        while (count.get() < n) {
-            Thread.sleep(100)
-        }
+        while count.get() < n do Thread.sleep(100)
 
     }
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AnnotationEndpointsSuite.scala
@@ -17,7 +17,15 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.{AnnotationController, TestUtils}
-import org.mbari.annosaurus.domain.{Annotation, AnnotationCreate, AnnotationSC, ConcurrentRequest, ConcurrentRequestCountSC, MultiRequest, MultiRequestCountSC}
+import org.mbari.annosaurus.domain.{
+    Annotation,
+    AnnotationCreate,
+    AnnotationSC,
+    ConcurrentRequest,
+    ConcurrentRequestCountSC,
+    MultiRequest,
+    MultiRequestCountSC
+}
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
@@ -503,17 +511,17 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
     }
 
     test("create (stress test)") {
-        val count = new AtomicInteger(0)
-        val jwt = jwtService.authorize("foo").orNull
-        val uuid = UUID.randomUUID()
+        val count       = new AtomicInteger(0)
+        val jwt         = jwtService.authorize("foo").orNull
+        val uuid        = UUID.randomUUID()
         assert(jwt != null)
         val backendStub = newBackendStub(endpoints.createAnnotationImpl)
-        val n = 1000
-        var threads = (0 until n)
+        val n           = 1000
+        var threads     = (0 until n)
             .map(i => TestUtils.build(1, 1).head)
             .map(im => {
                 val obs = im.getObservations.iterator.next()
-                val a = Annotation.from(obs)
+                val a   = Annotation.from(obs)
                 a.copy(videoReferenceUuid = Some(uuid), timecode = None)
             })
             .map(anno => {
@@ -542,7 +550,6 @@ trait AnnotationEndpointsSuite extends EndpointsSuite {
         while (count.get() < n) {
             Thread.sleep(100)
         }
-
 
     }
 }

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AssociationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AssociationEndpointsSuite.scala
@@ -17,24 +17,14 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.{AssociationController, TestUtils}
-import org.mbari.annosaurus.domain.{
-    Association,
-    AssociationSC,
-    AssociationUpdateSC,
-    ConceptAssociation,
-    ConceptAssociationRequest,
-    ConceptAssociationResponseSC,
-    ConceptCount,
-    RenameConcept,
-    RenameCountSC
-}
-import org.mbari.annosaurus.etc.jwt.JwtService
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import sttp.model.StatusCode
+import org.mbari.annosaurus.domain.{Association, AssociationSC, AssociationUpdateSC, ConceptAssociationRequest, ConceptAssociationResponseSC, ConceptCount, RenameConcept, RenameCountSC}
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import sttp.client3.*
+import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.etc.sdk.Reflect
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import sttp.client3.*
+import sttp.model.StatusCode
 
 import scala.jdk.CollectionConverters.*
 import scala.util.Random

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AssociationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AssociationEndpointsSuite.scala
@@ -39,7 +39,7 @@ import org.mbari.annosaurus.etc.sdk.Reflect
 import scala.jdk.CollectionConverters.*
 import scala.util.Random
 
-trait AssociationEndpointsSuite extends EndpointsSuite {
+trait AssociationEndpointsSuite extends EndpointsSuite:
 
     private val log              = System.getLogger(getClass.getName)
     given JPADAOFactory          = daoFactory
@@ -53,12 +53,11 @@ trait AssociationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAssociationByUuidImpl,
             s"/v1/associations/${a.getUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[AssociationSC](response.body)
                 val expected = Association.from(a, true).toSnakeCase
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -69,7 +68,7 @@ trait AssociationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAssociationsByVideoReferenceUuidAndLinkNameImpl,
             s"/v1/associations/${im.getVideoReferenceUuid}/${a.getLinkName}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val xs       = checkResponse[Seq[AssociationSC]](response.body)
                 assertEquals(xs.size, 1)
@@ -83,7 +82,6 @@ trait AssociationEndpointsSuite extends EndpointsSuite {
                     )
                     .toSnakeCase
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -97,7 +95,7 @@ trait AssociationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAssociationsByVideoReferenceUuidAndLinkNameImpl,
             s"/v1/associations/${im.getVideoReferenceUuid}/${a.getLinkName}?concept=${obs.getConcept}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val xs       = checkResponse[Seq[AssociationSC]](response.body)
                 assertEquals(xs.size, 1)
@@ -111,18 +109,16 @@ trait AssociationEndpointsSuite extends EndpointsSuite {
                     )
                     .toSnakeCase
                 assertEquals(obtained, expected)
-            }
         )
 
         // should return 0
         runGet(
             endpoints.findAssociationsByVideoReferenceUuidAndLinkNameImpl,
             s"/v1/associations/${im.getVideoReferenceUuid}/${a.getLinkName}?concept=robocop",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val xs = checkResponse[Seq[AssociationSC]](response.body)
                 assertEquals(xs.size, 0)
-            }
         )
     }
 
@@ -535,14 +531,11 @@ trait AssociationEndpointsSuite extends EndpointsSuite {
             endpoints.findAssociationsByConceptAssociationRequestImpl,
             s"/v1/associations/conceptassociations",
             car.stringify,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[ConceptAssociationResponseSC](response.body)
 //                println(obtained.stringify)
                 assertEquals(obtained.concept_associations.size, dtos.size)
                 // TODO check that the associations are the same
-            }
         )
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/AssociationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/AssociationEndpointsSuite.scala
@@ -17,7 +17,16 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.{AssociationController, TestUtils}
-import org.mbari.annosaurus.domain.{Association, AssociationSC, AssociationUpdateSC, ConceptAssociationRequest, ConceptAssociationResponseSC, ConceptCount, RenameConcept, RenameCountSC}
+import org.mbari.annosaurus.domain.{
+    Association,
+    AssociationSC,
+    AssociationUpdateSC,
+    ConceptAssociationRequest,
+    ConceptAssociationResponseSC,
+    ConceptCount,
+    RenameConcept,
+    RenameCountSC
+}
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.sdk.Futures.*

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/CachedAncillaryDatumEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/CachedAncillaryDatumEndpointsSuite.scala
@@ -32,7 +32,7 @@ import org.mbari.annosaurus.etc.sdk.Reflect
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import sttp.model.StatusCode
 
-trait CachedAncillaryDatumEndpointsSuite extends EndpointsSuite {
+trait CachedAncillaryDatumEndpointsSuite extends EndpointsSuite:
 
     private val log = System.getLogger(getClass.getName)
 
@@ -49,12 +49,11 @@ trait CachedAncillaryDatumEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findDataByUuidImpl,
             s"http://test.com/v1/ancillarydata/${d.getUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[CachedAncillaryDatumSC](response.body).toCamelCase
                 val expected = CachedAncillaryDatum.from(d, true)
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -64,13 +63,12 @@ trait CachedAncillaryDatumEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findDataByVideoReferenceUuidImpl,
             s"http://test.com/v1/ancillarydata/videoreference/${im.getVideoReferenceUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained =
                     checkResponse[List[CachedAncillaryDatumSC]](response.body).map(_.toCamelCase)
                 val expected = List(CachedAncillaryDatum.from(d, true))
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -80,12 +78,11 @@ trait CachedAncillaryDatumEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findDataByImagedMomentUuidImpl,
             s"http://test.com/v1/ancillarydata/imagedmoment/${im.getUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[CachedAncillaryDatumSC](response.body).toCamelCase
                 val expected = CachedAncillaryDatum.from(d, true)
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -96,12 +93,11 @@ trait CachedAncillaryDatumEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findDataByObservationUuidImpl,
             s"http://test.com/v1/ancillarydata/observation/${obs.getUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[CachedAncillaryDatumSC](response.body).toCamelCase
                 val expected = CachedAncillaryDatum.from(d, true)
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -265,5 +261,3 @@ trait CachedAncillaryDatumEndpointsSuite extends EndpointsSuite {
         val deleteCount        = checkResponse[CountForVideoReferenceSC](response.body)
         assertEquals(deleteCount.count, 2)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/CachedAncillaryDatumEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/CachedAncillaryDatumEndpointsSuite.scala
@@ -16,20 +16,15 @@
 
 package org.mbari.annosaurus.endpoints
 
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import sttp.client3.*
-import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.junit.Assert.*
 import org.mbari.annosaurus.controllers.{CachedAncillaryDatumController, TestUtils}
-import org.mbari.annosaurus.domain.{
-    CachedAncillaryDatum,
-    CachedAncillaryDatumSC,
-    CountForVideoReferenceSC,
-    DeleteCountSC
-}
+import org.mbari.annosaurus.domain.{CachedAncillaryDatum, CachedAncillaryDatumSC, CountForVideoReferenceSC}
+import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
+import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.etc.sdk.Reflect
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import sttp.client3.*
 import sttp.model.StatusCode
 
 trait CachedAncillaryDatumEndpointsSuite extends EndpointsSuite:

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/CachedAncillaryDatumEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/CachedAncillaryDatumEndpointsSuite.scala
@@ -16,7 +16,6 @@
 
 package org.mbari.annosaurus.endpoints
 
-import org.junit.Assert.*
 import org.mbari.annosaurus.controllers.{CachedAncillaryDatumController, TestUtils}
 import org.mbari.annosaurus.domain.{CachedAncillaryDatum, CachedAncillaryDatumSC, CountForVideoReferenceSC}
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/CachedVideoReferenceInfoEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/CachedVideoReferenceInfoEndpointsSuite.scala
@@ -37,7 +37,7 @@ import sttp.model.StatusCode
 
 import java.util.UUID
 
-trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
+trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite:
 
     private val log              = System.getLogger(getClass.getName)
     given JPADAOFactory          = daoFactory
@@ -45,7 +45,7 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
     lazy val controller          = new CachedVideoReferenceInfoController(daoFactory)
     lazy val endpoints           = new CachedVideoReferenceInfoEndpoints(controller)
 
-    def createVideoReferenceInfo(): CachedVideoReferenceInfo = {
+    def createVideoReferenceInfo(): CachedVideoReferenceInfo =
         val x = TestUtils.randomVideoReferenceInfo()
         controller
             .create(
@@ -55,14 +55,13 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
                 Option(x.getMissionContact)
             )
             .join
-    }
 
     test("findAll") {
         val xs = (0 until 3).map(_ => createVideoReferenceInfo())
         runGet(
             endpoints.findAllImpl,
             "http://test.com/v1/videoreferences",
-            response => {
+            response =>
                 assert(response.code == StatusCode.Ok)
                 val ys =
                     checkResponse[Seq[CachedVideoReferenceInfoSC]](response.body).map(_.toCamelCase)
@@ -73,7 +72,6 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
                             assertEquals(y, x)
                         case None    =>
                             fail(s"Could not find ${x.videoReferenceUuid}")
-            }
         )
     }
 
@@ -82,12 +80,11 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAllVideoReferenceUuidsImpl,
             "http://test.com/v1/videoreferences/videoreferences",
-            response => {
+            response =>
                 assert(response.code == StatusCode.Ok)
                 val ys = checkResponse[Seq[UUID]](response.body)
                 for x <- xs
                 do assert(ys.contains(x.videoReferenceUuid))
-            }
         )
     }
 
@@ -96,11 +93,10 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findByUuidImpl,
             s"http://test.com/v1/videoreferences/${x.uuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val y = checkResponse[CachedVideoReferenceInfoSC](response.body).toCamelCase
                 assertEquals(y, x)
-            }
         )
     }
 
@@ -109,11 +105,10 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findByVideoReferenceUuidImpl,
             s"http://test.com/v1/videoreferences/videoreference/${x.videoReferenceUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val y = checkResponse[CachedVideoReferenceInfoSC](response.body).toCamelCase
                 assertEquals(y, x)
-            }
         )
     }
 
@@ -122,12 +117,11 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAllMissionIdsImpl,
             "http://test.com/v1/videoreferences/missionids",
-            response => {
+            response =>
                 assert(response.code == StatusCode.Ok)
                 val ys = checkResponse[Seq[String]](response.body)
                 for x <- xs
                 do assert(ys.contains(x.missionId.get))
-            }
         )
     }
 
@@ -136,13 +130,12 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findByMissionIdImpl,
             s"http://test.com/v1/videoreferences/missionid/${x.missionId.get}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val y =
                     checkResponse[Seq[CachedVideoReferenceInfoSC]](response.body).map(_.toCamelCase)
                 assertEquals(y.size, 1)
                 assertEquals(y.head, x)
-            }
         )
     }
 
@@ -151,12 +144,11 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAllMissionContactsImpl,
             "http://test.com/v1/videoreferences/missioncontacts",
-            response => {
+            response =>
                 assert(response.code == StatusCode.Ok)
                 val ys = checkResponse[Seq[String]](response.body)
                 for x <- xs
                 do assert(ys.contains(x.missionContact.get))
-            }
         )
     }
 
@@ -165,13 +157,12 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findByMissionContactImpl,
             s"http://test.com/v1/videoreferences/missioncontact/${x.missionContact.get}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val y =
                     checkResponse[Seq[CachedVideoReferenceInfoSC]](response.body).map(_.toCamelCase)
                 assertEquals(y.size, 1)
                 assertEquals(y.head, x)
-            }
         )
     }
 
@@ -326,5 +317,3 @@ trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite {
             case None    =>
             // pass
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/CachedVideoReferenceInfoEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/CachedVideoReferenceInfoEndpointsSuite.scala
@@ -24,18 +24,15 @@ import org.mbari.annosaurus.domain.{
     CachedVideoReferenceInfoUpdateSC
 }
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import org.mbari.annosaurus.etc.jdk.Instants
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.etc.sdk.Reflect
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-
-import scala.jdk.CollectionConverters.*
 import sttp.client3.*
 import sttp.model.StatusCode
 
 import java.util.UUID
+import scala.jdk.CollectionConverters.*
 
 trait CachedVideoReferenceInfoEndpointsSuite extends EndpointsSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/EndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/EndpointsSuite.scala
@@ -20,18 +20,17 @@ import io.circe.*
 import io.circe.parser.*
 import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.repository.jpa.BaseDAOSuite
-import sttp.client3.*
 import sttp.client3.testing.SttpBackendStub
+import sttp.client3.{SttpBackend, *}
+import sttp.model.StatusCode
 import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.interceptor.CustomiseInterceptors
+import sttp.tapir.server.interceptor.exception.ExceptionHandler
+import sttp.tapir.server.model.ValuedEndpointOutput
 import sttp.tapir.server.stub.TapirStubInterpreter
+import sttp.tapir.server.vertx.VertxFutureServerOptions
 
 import scala.concurrent.Future
-import sttp.tapir.server.vertx.VertxFutureServerOptions
-import sttp.tapir.server.interceptor.exception.ExceptionHandler
-import sttp.tapir.server.interceptor.CustomiseInterceptors
-import sttp.model.StatusCode
-import sttp.client3.SttpBackend
-import sttp.tapir.server.model.ValuedEndpointOutput
 
 trait EndpointsSuite extends BaseDAOSuite:
 
@@ -130,7 +129,6 @@ trait EndpointsSuite extends BaseDAOSuite:
         )
 
         val customOptions: CustomiseInterceptors[Future, VertxFutureServerOptions] =
-            import scala.concurrent.ExecutionContext.Implicits.global
             VertxFutureServerOptions
                 .customiseInterceptors
                 .exceptionHandler(exceptionHandler)

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/EndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/EndpointsSuite.scala
@@ -113,10 +113,11 @@ trait EndpointsSuite extends BaseDAOSuite:
                     case Left(error)  => fail(error.getLocalizedMessage)
                     case Right(value) => value
 
-    /** Creates a stubbed backend for testing endpoints. Adds exception logging to the stub.
-      * @param serverEndpoint
-      * @return
-      */
+    /**
+     * Creates a stubbed backend for testing endpoints. Adds exception logging to the stub.
+     * @param serverEndpoint
+     * @return
+     */
     def newBackendStub(serverEndpoint: ServerEndpoint[Any, Future]): SttpBackend[Future, Any] =
         // --- START: This block adds exception logging to the stub
         val exceptionHandler = ExceptionHandler.pure[Future](ctx =>

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpointsSuite.scala
@@ -44,7 +44,7 @@ import org.junit.Assert.*
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
 
-trait FastAnnotationEndpointsSuite extends EndpointsSuite {
+trait FastAnnotationEndpointsSuite extends EndpointsSuite:
 
     private val log              = System.getLogger(getClass.getName)
     given JPADAOFactory          = daoFactory
@@ -57,7 +57,7 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAllAnnotationsImpl,
             "http://test.com/v1/fast?data=true",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val annotations = checkResponse[Seq[AnnotationSC]](response.body)
                 assert(annotations.size >= 4)
@@ -68,7 +68,6 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
                     assert(a.ancillary_data.isDefined)
 //                println(response.body)
 // TODO this is not returning the ancillary data
-            }
         )
     }
 
@@ -269,11 +268,10 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countAllAnnotationsImpl,
             "http://test.com/v1/fast/count",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[Count](response.body)
                 assert(count.count >= xs.size)
-            }
         )
     }
 
@@ -283,7 +281,7 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAnnotationsByVideoReferenceUuidImpl,
             s"http://test.com/v1/fast/videoreference/$videoReferenceUuid?data=true",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val annotations = checkResponse[Seq[AnnotationSC]](response.body)
                 assertEquals(annotations.size, 4)
@@ -292,7 +290,6 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
                     assertEquals(a.image_references.size, 1)
                     assertEquals(a.associations.size, 1)
                     assert(a.ancillary_data.isDefined)
-            }
         )
     }
 
@@ -302,11 +299,10 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagesByVideoReferenceUuidImpl,
             s"http://test.com/v1/fast/images/videoreference/$videoReferenceUuid",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val images = checkResponse[Seq[ImageSC]](response.body)
                 assertEquals(images.size, xs.size)
-            }
         )
     }
 
@@ -316,11 +312,10 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countImagesByVideoReferenceUuidImpl,
             s"http://test.com/v1/fast/images/count/videoreference/$videoReferenceUuid",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[Count](response.body)
                 assertEquals(count.count, xs.size.longValue)
-            }
         )
     }
 
@@ -330,7 +325,7 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAnnotationsByConceptImpl,
             s"http://test.com/v1/fast/concept/$concept?data=true",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val annotations = checkResponse[Seq[AnnotationSC]](response.body)
                 assertEquals(annotations.size, 1)
@@ -340,7 +335,6 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
                     assertEquals(a.image_references.size, 1)
                     assertEquals(a.associations.size, 1)
                     assert(a.ancillary_data.isDefined)
-            }
         )
     }
 
@@ -350,7 +344,7 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAnnotationsWithImagesByConceptImpl,
             s"http://test.com/v1/fast/concept/images/$concept?data=true",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val annotations = checkResponse[Seq[AnnotationSC]](response.body)
                 assertEquals(annotations.size, 1)
@@ -359,7 +353,6 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
                     assertEquals(a.image_references.size, 1)
                     assertEquals(a.associations.size, 1)
                     assert(a.ancillary_data.isDefined)
-            }
         )
     }
 
@@ -369,11 +362,10 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagedMomentUuidsByConceptImpl,
             s"http://test.com/v1/fast/imagedmoments/concept/images/$concept",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMomentUuids = checkResponse[Seq[String]](response.body)
                 assertEquals(imagedMomentUuids.size, 1)
-            }
         )
     }
 
@@ -385,12 +377,11 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagedMomentUuidsByToConceptImpl,
             s"http://test.com/v1/fast/imagedmoments/toconcept/images/$toConcept",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMomentUuids = checkResponse[Seq[UUID]](response.body)
                 assertEquals(imagedMomentUuids.size, 1)
                 assertEquals(imagedMomentUuids.head, im.getUuid)
-            }
         )
     }
 
@@ -403,7 +394,7 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAnnotationsByLinkNameAndLinkValueImpl,
             s"http://test.com/v1/fast/details/${ass.getLinkName}/${ass.getLinkValue}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val annos    = checkResponse[Seq[AnnotationSC]](response.body)
                 assertEquals(annos.size, 1)
@@ -412,7 +403,6 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
 //                println("EXPECTED: " + expected.stringify)
 //                println("OBTAINED: " + obtained.stringify)
                 assertEquals(obtained, expected)
-            }
         )
 
     }
@@ -446,13 +436,12 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
             endpoints.findAnnotationsByConcurrentRequestImpl,
             "http://test.com/v1/fast/concurrent",
             body,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val annotations = checkResponse[Seq[AnnotationSC]](response.body)
                 val expected    = xs.flatMap(_.getObservations.asScala).size
                 val obtained    = annotations.size
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -466,15 +455,12 @@ trait FastAnnotationEndpointsSuite extends EndpointsSuite {
             endpoints.findAnnotationsByMultiRequestImpl,
             "http://test.com/v1/fast/multi",
             body,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val annotations = checkResponse[Seq[AnnotationSC]](response.body)
                 val expected    = xs.flatMap(_.getObservations.asScala).size
                 val obtained    = annotations.size
                 assertEquals(obtained, expected)
-            }
         )
 
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpointsSuite.scala
@@ -17,7 +17,19 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.TestUtils
-import org.mbari.annosaurus.domain.{Annotation, AnnotationSC, CachedAncillaryDatum, ConcurrentRequest, Count, DeleteCountSC, GeographicRangeSC, ImageSC, MultiRequest, QueryConstraints, QueryConstraintsResponseSC}
+import org.mbari.annosaurus.domain.{
+    Annotation,
+    AnnotationSC,
+    CachedAncillaryDatum,
+    ConcurrentRequest,
+    Count,
+    DeleteCountSC,
+    GeographicRangeSC,
+    ImageSC,
+    MultiRequest,
+    QueryConstraints,
+    QueryConstraintsResponseSC
+}
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.sdk.Futures.*

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/FastAnnotationEndpointsSuite.scala
@@ -17,29 +17,14 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.TestUtils
-import org.mbari.annosaurus.domain.{
-    Annotation,
-    AnnotationSC,
-    CachedAncillaryDatum,
-    ConcurrentRequest,
-    Count,
-    DeleteCount,
-    DeleteCountSC,
-    GeographicRange,
-    GeographicRangeSC,
-    ImageSC,
-    MultiRequest,
-    QueryConstraints,
-    QueryConstraintsResponseSC
-}
+import org.mbari.annosaurus.domain.{Annotation, AnnotationSC, CachedAncillaryDatum, ConcurrentRequest, Count, DeleteCountSC, GeographicRangeSC, ImageSC, MultiRequest, QueryConstraints, QueryConstraintsResponseSC}
+import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
+import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.repository.jdbc.JdbcRepository
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import sttp.model.StatusCode
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import sttp.client3.*
-import org.mbari.annosaurus.etc.sdk.Futures.*
-import org.junit.Assert.*
+import sttp.model.StatusCode
 
 import java.util.UUID
 import scala.jdk.CollectionConverters.*

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ImageEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ImageEndpointsSuite.scala
@@ -18,13 +18,13 @@ package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.{ImageController, TestUtils}
 import org.mbari.annosaurus.domain.{Image, ImageCreateSC, ImageSC, ImageUpdateSC}
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import sttp.model.StatusCode
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.etc.sdk.Reflect
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import sttp.client3.*
+import sttp.model.StatusCode
 
 import java.net.{URI, URLEncoder}
 import java.nio.charset.StandardCharsets

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ImageEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ImageEndpointsSuite.scala
@@ -29,7 +29,7 @@ import sttp.client3.*
 import java.net.{URI, URLEncoder}
 import java.nio.charset.StandardCharsets
 
-trait ImageEndpointsSuite extends EndpointsSuite {
+trait ImageEndpointsSuite extends EndpointsSuite:
 
     private val log              = System.getLogger(getClass.getName)
     given JPADAOFactory          = daoFactory
@@ -43,12 +43,11 @@ trait ImageEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findOneImageImpl,
             s"/v1/images/${ir.getUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[ImageSC](response.body)
                 val expected = Image.from(ir, true).toSnakeCase
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -58,13 +57,12 @@ trait ImageEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findByVideoReferenceUUIDImpl,
             s"/v1/images/videoreference/${im.getVideoReferenceUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[Seq[ImageSC]](response.body)
                 assertEquals(obtained.size, 1)
                 val expected = Image.from(ir, true).toSnakeCase
                 assertEquals(obtained.head, expected)
-            }
         )
     }
 
@@ -74,11 +72,10 @@ trait ImageEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findByVideoReferenceUUIDImpl,
             s"/v1/images/videoreference/${im.getVideoReferenceUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[Seq[ImageSC]](response.body)
                 assertEquals(obtained.size, 10)
-            }
         )
     }
 
@@ -89,13 +86,12 @@ trait ImageEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findByImageNameImpl,
             s"/v1/images/name/${imageName}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[Seq[ImageSC]](response.body)
                 assertEquals(obtained.size, 1)
                 val expected = Image.from(ir, true).toSnakeCase
                 assertEquals(obtained.head, expected)
-            }
         )
     }
 
@@ -107,12 +103,11 @@ trait ImageEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findByImageUrlImpl,
             s"/v1/images/url/${url}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[ImageSC](response.body)
                 val expected = Image.from(ir, true).toSnakeCase
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -225,5 +220,3 @@ trait ImageEndpointsSuite extends EndpointsSuite {
         assertEquals(obtained, expected)
 
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ImageReferenceEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ImageReferenceEndpointsSuite.scala
@@ -29,7 +29,7 @@ import org.mbari.annosaurus.etc.sdk.Reflect
 
 import scala.jdk.CollectionConverters.*
 
-trait ImageReferenceEndpointsSuite extends EndpointsSuite {
+trait ImageReferenceEndpointsSuite extends EndpointsSuite:
 
     given JPADAOFactory          = daoFactory
     private val log              = System.getLogger(getClass.getName)
@@ -61,12 +61,11 @@ trait ImageReferenceEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImageByUuidImpl,
             s"http://test.com/v1/imagereferences/${imageReference.getUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[ImageReferenceSC](response.body).toCamelCase
                 val expected = ImageReference.from(imageReference, true)
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -124,5 +123,3 @@ trait ImageReferenceEndpointsSuite extends EndpointsSuite {
         )
         assertEquals(obtained, expected)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ImageReferenceEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ImageReferenceEndpointsSuite.scala
@@ -18,14 +18,13 @@ package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.{ImageReferenceController, TestUtils}
 import org.mbari.annosaurus.domain.{ImageReference, ImageReferenceSC}
-import org.mbari.annosaurus.etc.jwt.JwtService
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
-import sttp.client3.*
-import org.mbari.annosaurus.etc.sdk.Futures.*
-import sttp.model.StatusCode
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
+import org.mbari.annosaurus.etc.jwt.JwtService
+import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.etc.sdk.Reflect
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import sttp.client3.*
+import sttp.model.StatusCode
 
 import scala.jdk.CollectionConverters.*
 

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpointsSuite.scala
@@ -16,7 +16,6 @@
 
 package org.mbari.annosaurus.endpoints
 
-import java.time.{Duration, Instant}
 import org.mbari.annosaurus.controllers.{ImagedMomentController, TestUtils}
 import org.mbari.annosaurus.domain.{
     Annotation,
@@ -31,13 +30,14 @@ import org.mbari.annosaurus.domain.{
 }
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.jdk.Instants
-import org.mbari.annosaurus.etc.jdk.Logging.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.sdk.Futures.*
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import scala.jdk.CollectionConverters.*
 import sttp.client3.*
 import sttp.model.StatusCode
+
+import java.time.{Duration, Instant}
+import scala.jdk.CollectionConverters.*
 
 trait ImagedMomentEndpointsSuite extends EndpointsSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpointsSuite.scala
@@ -573,7 +573,7 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         assert(imagedMoment.isEmpty)
     }
 
-    test("bulkMove") {
+    test("bulkMove (camelCase)") {
         val xs          = TestUtils.create(4)
         val newVideoRef = java.util.UUID.randomUUID()
         val moveRequest = MoveImagedMoments(newVideoRef, xs.map(_.getUuid))
@@ -585,6 +585,27 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
             .header("Authorization", s"Bearer $jwt")
             .header("Content-Type", "application/json")
             .body(moveRequest.stringify)
+            .send(backendStub)
+            .join
+
+        assertEquals(response.code, StatusCode.Ok)
+        val count = checkResponse[Count](response.body)
+        assertEquals(count.count.intValue, xs.size)
+            
+    }
+
+    test("bulkMove (snake_case)") {
+        val xs          = TestUtils.create(4)
+        val newVideoRef = java.util.UUID.randomUUID()
+        val moveRequest = MoveImagedMoments(newVideoRef, xs.map(_.getUuid))
+        val jwt         = jwtService.authorize("foo").orNull
+        assert(jwt != null)
+        val backendStub = newBackendStub(endpoints.bulkMoveImpl)
+        val response    = basicRequest
+            .put(uri"http://test.com/v1/imagedmoments/bulk/move")
+            .header("Authorization", s"Bearer $jwt")
+            .header("Content-Type", "application/json")
+            .body(moveRequest.toSnakeCase.stringify)
             .send(backendStub)
             .join
 

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpointsSuite.scala
@@ -591,7 +591,7 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         assertEquals(response.code, StatusCode.Ok)
         val count = checkResponse[Count](response.body)
         assertEquals(count.count.intValue, xs.size)
-            
+
     }
 
     test("bulkMove (snake_case)") {
@@ -612,6 +612,6 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         assertEquals(response.code, StatusCode.Ok)
         val count = checkResponse[Count](response.body)
         assertEquals(count.count.intValue, xs.size)
-            
+
     }
 }

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ImagedMomentEndpointsSuite.scala
@@ -39,7 +39,7 @@ import scala.jdk.CollectionConverters.*
 import sttp.client3.*
 import sttp.model.StatusCode
 
-trait ImagedMomentEndpointsSuite extends EndpointsSuite {
+trait ImagedMomentEndpointsSuite extends EndpointsSuite:
 
     private val log              = System.getLogger(getClass.getName)
     given JPADAOFactory          = daoFactory
@@ -52,11 +52,10 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAllImagedMomentsImpl,
             s"http://test.com/v1/imagedmoments?limit=10&offset=0",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoments = checkResponse[Seq[ImagedMomentSC]](response.body)
                 assert(imagedMoments.size >= 2)
-            }
         )
     }
 
@@ -65,11 +64,10 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countAllImagedMomentsImpl,
             s"http://test.com/v1/imagedmoments/count/all",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[Count](response.body)
                 assert(count.count >= 2)
-            }
         )
     }
 
@@ -78,14 +76,13 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagedMomentsWithImagesImpl,
             s"http://test.com/v1/imagedmoments/find/images?limit=10&offset=0",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoments = checkResponse[Seq[ImagedMomentSC]](response.body)
                 assert(imagedMoments.nonEmpty)
                 val expected      = ImagedMoment.from(im, true)
                 val obtained      = imagedMoments.filter(_.uuid.get == im.getUuid).head.toCamelCase
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -94,11 +91,10 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countImagedMomentsWithImagesImpl,
             s"http://test.com/v1/imagedmoments/count/images",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[Count](response.body)
                 assert(count.count >= 1)
-            }
         )
     }
 
@@ -107,22 +103,20 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countImagesForVideoReferenceImpl,
             s"http://test.com/v1/imagedmoments/count/images/${xs.head.getVideoReferenceUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[Count](response.body)
                 assertEquals(count.count, xs.size.longValue)
-            }
         )
 
         val uuid = java.util.UUID.randomUUID()
         runGet(
             endpoints.countImagesForVideoReferenceImpl,
             s"http://test.com/v1/imagedmoments/count/images/$uuid",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[Count](response.body)
                 assertEquals(count.count, 0L)
-            }
         )
     }
 
@@ -133,25 +127,23 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagedMomentsByLinkNameImpl,
             s"http://test.com/v1/imagedmoments/find/linkname/${linkName}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoments = checkResponse[Seq[ImagedMomentSC]](response.body)
                 assertEquals(imagedMoments.size, 1)
                 val expected      = ImagedMoment.from(im, true)
                 val obtained      = imagedMoments.head.toCamelCase
                 assertEquals(obtained, expected)
-            }
         )
 
         val linkName1 = "foo"
         runGet(
             endpoints.findImagedMomentsByLinkNameImpl,
             s"http://test.com/v1/imagedmoments/find/linkname/$linkName1",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoments = checkResponse[Seq[ImagedMomentSC]](response.body)
                 assert(imagedMoments.isEmpty)
-            }
         )
     }
 
@@ -162,11 +154,10 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countImagedMomentsByLinkNameImpl,
             s"http://test.com/v1/imagedmoments/count/linkname/$linkName",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[Count](response.body)
                 assertEquals(count.count, 1.longValue)
-            }
         )
     }
 
@@ -175,12 +166,11 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagedMomentByUUIDImpl,
             s"http://test.com/v1/imagedmoments/${im.getUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[ImagedMomentSC](response.body).toCamelCase
                 val expected = ImagedMoment.from(im, true)
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -190,14 +180,13 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagedMomentsByConceptNameImpl,
             s"http://test.com/v1/imagedmoments/concept/$concept",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoments = checkResponse[Seq[ImagedMomentSC]](response.body)
                 assertEquals(imagedMoments.size, 1)
                 val expected      = ImagedMoment.from(im, true)
                 val obtained      = imagedMoments.head.toCamelCase
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -207,14 +196,13 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagedMomentsByConceptNameWithImagesImpl,
             s"http://test.com/v1/imagedmoments/concept/images/$concept",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoments = checkResponse[Seq[ImagedMomentSC]](response.body)
                 assertEquals(imagedMoments.size, 1)
                 val expected      = ImagedMoment.from(im, true)
                 val obtained      = imagedMoments.head.toCamelCase
                 assertEquals(obtained, expected)
-            }
         )
 
         val im0      = TestUtils.create(1, 1).head
@@ -222,11 +210,10 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagedMomentsByConceptNameWithImagesImpl,
             s"http://test.com/v1/imagedmoments/concept/images/$concept0",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoments = checkResponse[Seq[ImagedMomentSC]](response.body)
                 assert(imagedMoments.isEmpty)
-            }
         )
     }
 
@@ -242,12 +229,11 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countImagedMomentsByConceptNameImpl,
             s"http://test.com/v1/imagedmoments/concept/count/$concept",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[ConceptCount](response.body)
                 assertEquals(count.concept, concept)
                 assertEquals(count.count, 4L)
-            }
         )
     }
 
@@ -263,12 +249,11 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countImagedMomentsByConceptNameWithImagesImpl,
             s"http://test.com/v1/imagedmoments/concept/images/count/$concept",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[ConceptCount](response.body)
                 assertEquals(count.concept, concept)
                 assertEquals(count.count, xs.size.longValue)
-            }
         )
     }
 
@@ -283,7 +268,7 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagedMomentsBetweenModifiedDatesImpl,
             s"http://test.com/v1/imagedmoments/modified/$startString/$endString?limit=10&offset=0",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoments = checkResponse[Seq[ImagedMomentSC]](response.body)
                 assert(imagedMoments.size >= xs.size)
@@ -294,7 +279,6 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
                     val expected = ImagedMoment.from(x, true)
                     val obtained = im.toCamelCase
                     assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -309,11 +293,10 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countImagedMomentsBetweenModifiedDatesImpl,
             s"http://test.com/v1/imagedmoments/modified/count/$startString/$endString",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[Count](response.body)
                 assert(count.count >= xs.size)
-            }
         )
     }
 
@@ -322,7 +305,7 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countsPerVideoReferenceImpl,
             s"http://test.com/v1/imagedmoments/counts",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val counts = checkResponse[Seq[CountForVideoReferenceSC]](response.body)
                 assert(counts.size >= 2)
@@ -330,7 +313,6 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
                     (videoReferenceUuid, imagedMoments) <- xs.groupBy(_.getVideoReferenceUuid)
                     count                               <- counts.find(_.video_reference_uuid == videoReferenceUuid)
                 do assertEquals(count.count, imagedMoments.size)
-            }
         )
     }
 
@@ -339,13 +321,12 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAllVideoReferenceUUIDsImpl,
             s"http://test.com/v1/imagedmoments/videoreference",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val uuids = checkResponse[Seq[java.util.UUID]](response.body)
                 assert(uuids.size >= 2)
                 for x <- xs
                 do assert(uuids.contains(x.getVideoReferenceUuid))
-            }
         )
     }
 
@@ -355,7 +336,7 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findImagedMomentsByVideoReferenceUuidImpl,
             s"http://test.com/v1/imagedmoments/videoreference/${videoReferenceUuid}?limit=10&offset=0",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoments = checkResponse[Seq[ImagedMomentSC]](response.body)
                 assertEquals(imagedMoments.size, xs.size)
@@ -366,7 +347,6 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
                     val expected = ImagedMoment.from(x, true)
                     val obtained = im.toCamelCase
                     assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -379,11 +359,10 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countModifiedBeforeDateImpl,
             s"http://test.com/v1/imagedmoments/videoreference/modified/${im.getVideoReferenceUuid}/$startString",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[CountForVideoReferenceSC](response.body)
                 assertEquals(count.count, xs.size)
-            }
         )
     }
 
@@ -397,7 +376,7 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
             endpoints.findImagedMomentsByWindowRequestImpl,
             s"http://test.com/v1/imagedmoments/windowrequest",
             windowRequest.toSnakeCase.stringify,
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoments = checkResponse[Seq[ImagedMomentSC]](response.body)
                 assertEquals(imagedMoments.size, xs.size)
@@ -408,7 +387,6 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
                     val expected = ImagedMoment.from(x, true).copy(lastUpdated = None)
                     val obtained = im.toCamelCase.copy(lastUpdated = None)
                     assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -418,12 +396,11 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runDelete(
             endpoints.deleteByVideoReferenceUUIDImpl,
             s"http://test.com/v1/imagedmoments/videoreference/${videoReferenceUuid}",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val count = checkResponse[CountForVideoReferenceSC](response.body)
                 assertEquals(count.video_reference_uuid, videoReferenceUuid)
                 assertEquals(count.count, xs.size)
-            }
         )
         val c                  = ImagedMomentController(daoFactory)
         val imagedMoments      = c.findByVideoReferenceUUID(videoReferenceUuid).join
@@ -436,13 +413,12 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findByImageReferenceUUIDImpl,
             s"http://test.com/v1/imagedmoments/imagereference/${imageReferenceUuid}?limit=10&offset=0",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoment = checkResponse[ImagedMomentSC](response.body)
                 val expected     = ImagedMoment.from(im, true)
                 val obtained     = imagedMoment.toCamelCase
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -452,13 +428,12 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findByObservationUUIDImpl,
             s"http://test.com/v1/imagedmoments/observation/${observationUuid}?limit=10&offset=0",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val imagedMoment = checkResponse[ImagedMomentSC](response.body)
                 val expected     = ImagedMoment.from(im, true)
                 val obtained     = imagedMoment.toCamelCase
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -614,4 +589,3 @@ trait ImagedMomentEndpointsSuite extends EndpointsSuite {
         assertEquals(count.count.intValue, xs.size)
 
     }
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/IndexEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/IndexEndpointsSuite.scala
@@ -32,7 +32,7 @@ import org.mbari.annosaurus.etc.sdk.Futures.*
 import java.time.{Duration, Instant}
 import scala.util.Random
 
-trait IndexEndpointsSuite extends EndpointsSuite {
+trait IndexEndpointsSuite extends EndpointsSuite:
 
     private val log = System.getLogger(getClass.getName)
 
@@ -90,5 +90,3 @@ trait IndexEndpointsSuite extends EndpointsSuite {
             val obtained = i.recorded_timestamp.get
             assertEquals(obtained, expected)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/IndexEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/IndexEndpointsSuite.scala
@@ -16,21 +16,17 @@
 
 package org.mbari.annosaurus.endpoints
 
-import org.mbari.annosaurus.controllers.IndexController
-import org.mbari.annosaurus.controllers.TestUtils
+import org.mbari.annosaurus.controllers.{IndexController, TestUtils}
 import org.mbari.annosaurus.domain
-import org.mbari.annosaurus.domain.{ImagedMoment, Index, IndexSC, IndexUpdate}
-import sttp.model.StatusCode
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.etc.jwt.JwtService
-import org.mbari.annosaurus.etc.circe.CirceCodecs.given
-import org.mbari.annosaurus.etc.jdk.Instants
-import sttp.client3.*
+import org.mbari.annosaurus.domain.{Index, IndexSC, IndexUpdate}
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
+import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.sdk.Futures.*
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import sttp.client3.*
+import sttp.model.StatusCode
 
 import java.time.{Duration, Instant}
-import scala.util.Random
 
 trait IndexEndpointsSuite extends EndpointsSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpointsSuite.scala
@@ -16,31 +16,14 @@
 
 package org.mbari.annosaurus.endpoints
 
-import org.mbari.annosaurus.Endpoints.daoFactory
 import org.mbari.annosaurus.controllers.{ImagedMomentController, ObservationController, TestUtils}
-import org.mbari.annosaurus.domain.{
-    ConceptCount,
-    Count,
-    CountForVideoReferenceSC,
-    ImagedMoment,
-    Observation,
-    ObservationSC,
-    ObservationUpdateSC,
-    ObservationsUpdate,
-    RenameConcept,
-    RenameCountSC
-}
-import org.mbari.annosaurus.etc.jwt.JwtService
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
-import org.mbari.annosaurus.etc.sdk.Futures.join
-import sttp.tapir.*
-import sttp.tapir.json.circe.*
-import sttp.tapir.generic.auto.*
-import sttp.tapir.server.ServerEndpoint
+import org.mbari.annosaurus.domain.{ConceptCount, Count, CountForVideoReferenceSC, Observation, ObservationSC, ObservationUpdateSC, ObservationsUpdate, RenameConcept, RenameCountSC}
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
+import org.mbari.annosaurus.etc.jwt.JwtService
+import org.mbari.annosaurus.etc.sdk.Futures.join
 import org.mbari.annosaurus.etc.sdk.Reflect
 import org.mbari.annosaurus.repository.jdbc.JdbcRepository
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import sttp.client3.*
 import sttp.model.StatusCode
 

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpointsSuite.scala
@@ -17,7 +17,17 @@
 package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.controllers.{ImagedMomentController, ObservationController, TestUtils}
-import org.mbari.annosaurus.domain.{ConceptCount, Count, CountForVideoReferenceSC, Observation, ObservationSC, ObservationUpdateSC, ObservationsUpdate, RenameConcept, RenameCountSC}
+import org.mbari.annosaurus.domain.{
+    ConceptCount,
+    Count,
+    CountForVideoReferenceSC,
+    Observation,
+    ObservationSC,
+    ObservationUpdateSC,
+    ObservationsUpdate,
+    RenameConcept,
+    RenameCountSC
+}
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.etc.sdk.Futures.join

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpointsSuite.scala
@@ -49,7 +49,7 @@ import java.util.UUID
 import scala.jdk.CollectionConverters.*
 import scala.util.Random
 
-trait ObservationEndpointsSuite extends EndpointsSuite {
+trait ObservationEndpointsSuite extends EndpointsSuite:
 
     private val log = System.getLogger(getClass.getName)
 
@@ -67,12 +67,11 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findObservationByUuidImpl,
             s"http://test.com/v1/observations/$uuid",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val expected = Observation.from(observation, true)
                 val obtained = checkResponse[ObservationSC](response.body).toCamelCase
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -82,7 +81,7 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findObservationsByVideoReferenceUuidImpl,
             s"http://test.com/v1/observations/videoreference/$videoReferenceUuid",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val expected = xs
                     .flatMap(_.getObservations.asScala)
@@ -94,7 +93,6 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
                     .sortBy(_.uuid)
                     .toSet
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -109,12 +107,11 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findActivitiesImpl,
             s"http://test.com/v1/observations/activities",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[Seq[String]](response.body).sorted
                 for a <- expected
                 do assert(obtained.contains(a))
-            }
         )
     }
 
@@ -125,12 +122,11 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findObservationByAssociationUuidImpl,
             s"http://test.com/v1/observations/association/$associationUuid",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val expected = Observation.from(im.getObservations.iterator().next(), true)
                 val obtained = checkResponse[ObservationSC](response.body).toCamelCase
                 assertEquals(obtained, expected)
-            }
         )
     }
 
@@ -146,12 +142,11 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findAllConceptsImpl,
             s"http://test.com/v1/observations/concepts",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[Seq[String]](response.body).sorted
                 for c <- expected
                 do assert(obtained.contains(c))
-            }
         )
     }
 
@@ -168,13 +163,12 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findConceptsByVideoReferenceUuidImpl,
             s"http://test.com/v1/observations/concepts/$videoReferenceUuid",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[Seq[String]](response.body).sorted
                 assertEquals(obtained.size, expected.size)
                 for c <- expected
                 do assert(obtained.contains(c))
-            }
         )
     }
 
@@ -192,12 +186,11 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countObservationsByConceptImpl,
             s"http://test.com/v1/observations/concept/count/$concept",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[ConceptCount](response.body)
                 assertEquals(obtained.concept, concept)
                 assertEquals(obtained.count, expected.longValue)
-            }
         )
     }
 
@@ -211,12 +204,11 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countImagesByConceptImpl,
             s"http://test.com/v1/observations/concept/images/count/$concept",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[ConceptCount](response.body)
                 assertEquals(obtained.concept, concept)
                 assertEquals(obtained.count, expected.longValue)
-            }
         )
     }
 
@@ -232,12 +224,11 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.findGroupsImpl,
             "http://test.com/v1/observations/groups",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[Seq[String]](response.body).sorted
                 for a <- expected
                 do assert(obtained.contains(a))
-            }
         )
     }
 
@@ -250,11 +241,10 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countByVideoReferenceUuidImpl,
             s"http://test.com/v1/observations/videoreference/count/$videoReferenceUuid",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[CountForVideoReferenceSC](response.body)
                 assertEquals(obtained.count, expected)
-            }
         )
 
         // Test with start/end
@@ -263,11 +253,10 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countByVideoReferenceUuidImpl,
             s"http://test.com/v1/observations/videoreference/count/$videoReferenceUuid?start=$t0&end=$t1",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[CountForVideoReferenceSC](response.body)
                 assertEquals(obtained.count, expected)
-            }
         )
 
         // Test with start/end that should return no results
@@ -275,22 +264,20 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countByVideoReferenceUuidImpl,
             s"http://test.com/v1/observations/videoreference/count/$videoReferenceUuid?start=$t1&end=$t2",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[CountForVideoReferenceSC](response.body)
                 assertEquals(obtained.count, 0)
-            }
         )
 
         // Test with bogus videoreference uuid but valid start/end that should return no results
         runGet(
             endpoints.countByVideoReferenceUuidImpl,
             s"http://test.com/v1/observations/videoreference/count/${UUID.randomUUID()}?start=$t0&end=$t1",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val obtained = checkResponse[CountForVideoReferenceSC](response.body)
                 assertEquals(obtained.count, 0)
-            }
         )
     }
 
@@ -300,18 +287,15 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
         runGet(
             endpoints.countAllGroupByVideoReferenceUuidImpl,
             s"http://test.com/v1/observations/counts",
-            response => {
+            response =>
                 assertEquals(response.code, StatusCode.Ok)
                 val results = checkResponse[Seq[CountForVideoReferenceSC]](response.body)
-                results.find(_.video_reference_uuid == videoReferenceUuid) match {
+                results.find(_.video_reference_uuid == videoReferenceUuid) match
                     case Some(result) => assertEquals(result.count, im.getObservations.size)
                     case None         =>
                         fail(
                             s"Expected to find a result with videoreference uuid $videoReferenceUuid"
                         )
-                }
-
-            }
         )
     }
 
@@ -551,5 +535,3 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
             assertEquals(obtained.group, update.group)
 
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/ObservationEndpointsSuite.scala
@@ -18,7 +18,18 @@ package org.mbari.annosaurus.endpoints
 
 import org.mbari.annosaurus.Endpoints.daoFactory
 import org.mbari.annosaurus.controllers.{ImagedMomentController, ObservationController, TestUtils}
-import org.mbari.annosaurus.domain.{ConceptCount, Count, CountForVideoReferenceSC, ImagedMoment, Observation, ObservationSC, ObservationUpdateSC, ObservationsUpdate, RenameConcept, RenameCountSC}
+import org.mbari.annosaurus.domain.{
+    ConceptCount,
+    Count,
+    CountForVideoReferenceSC,
+    ImagedMoment,
+    Observation,
+    ObservationSC,
+    ObservationUpdateSC,
+    ObservationsUpdate,
+    RenameConcept,
+    RenameCountSC
+}
 import org.mbari.annosaurus.etc.jwt.JwtService
 import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import org.mbari.annosaurus.etc.tapir.TapirCodecs.given
@@ -44,11 +55,10 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
 
     given JPADAOFactory = daoFactory
 
-    given jwtService: JwtService = new JwtService("mbari", "foo", "bar")
-    private lazy val controller  = ObservationController(daoFactory)
-    private lazy val jdbcRepository     = new JdbcRepository(daoFactory.entityManagerFactory)
-    private lazy val endpoints   = new ObservationEndpoints(controller, jdbcRepository)
-
+    given jwtService: JwtService    = new JwtService("mbari", "foo", "bar")
+    private lazy val controller     = ObservationController(daoFactory)
+    private lazy val jdbcRepository = new JdbcRepository(daoFactory.entityManagerFactory)
+    private lazy val endpoints      = new ObservationEndpoints(controller, jdbcRepository)
 
     test("findObservationByUuid") {
         val im          = TestUtils.create(1, 1).head
@@ -509,12 +519,13 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
     test("updateManyObservations") {
         val im               = TestUtils.create(20, 2)
         val observationUuids = im.flatMap(_.getObservations.asScala.map(_.getUuid)).toSeq
-        val update = ObservationsUpdate(
+        val update           = ObservationsUpdate(
             observationUuids,
             concept = Some("new-concept"),
             observer = Some("new-observer"),
             activity = Some("new-activity"),
-            group = Some("new-group"))
+            group = Some("new-group")
+        )
         val jwt              = jwtService.authorize("foo").orNull
         assert(jwt != null)
         val backend          = newBackendStub(endpoints.updateManyObservationsImpl)
@@ -526,13 +537,12 @@ trait ObservationEndpointsSuite extends EndpointsSuite {
             .body(update.stringify)
             .send(backend)
             .join
-        val obtained = checkResponse[Count](response.body)
+        val obtained         = checkResponse[Count](response.body)
         assertEquals(obtained.count, observationUuids.size.toLong)
 
-        for
-            uuid <- observationUuids
+        for uuid <- observationUuids
         do
-            val opt = controller.findByUUID(uuid).join
+            val opt      = controller.findByUUID(uuid).join
             assert(opt.isDefined)
             val obtained = opt.get
             assertEquals(obtained.concept, update.concept.get)

--- a/it/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/endpoints/QueryEndpointsSuite.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.endpoints
+
+import org.mbari.annosaurus.controllers.{QueryController, TestUtils}
+import org.mbari.annosaurus.domain.{ConstraintRequest, Count, QueryRequest}
+import org.mbari.annosaurus.repository.jpa.JPADAOFactory
+import org.mbari.annosaurus.repository.query.JDBC
+import org.mbari.annosaurus.etc.jdk.Loggers.{*, given}
+import sttp.model.StatusCode
+import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
+
+import scala.jdk.CollectionConverters.*
+
+trait QueryEndpointsSuite extends EndpointsSuite {
+
+    private val log = System.getLogger(getClass.getName)
+
+    given JPADAOFactory = daoFactory
+
+    private lazy val controller = new QueryController(daoFactory.databaseConfig, daoFactory.annotationView)
+    private lazy val endpoints = new QueryEndpoints(controller)
+
+    test("listColumns") {
+        runGet(endpoints.listColumnsImpl,
+            s"http://test.com/v1/query/columns",
+            response =>
+                assertEquals(response.code, StatusCode.Ok)
+                val obtained = checkResponse[Seq[JDBC.Metadata]](response.body)
+//                log.atDebug.log(s"Columns: $obtained")
+                assert(obtained.nonEmpty)
+        )
+    }
+
+    test("runQuery") {
+        val xs = TestUtils.create(2, 2)
+        val expected = ("concept" +: xs.flatMap(_.getObservations.asScala.map(_.getConcept))).distinct.sorted.mkString("\n")
+        val queryRequest = QueryRequest(select = Some(Seq("concept")), distinct = Some(true))
+        runPost(endpoints.runQueryImpl,
+            s"http://test.com/v1/query/run",
+            queryRequest.stringify,
+            response =>
+                assertEquals(response.code, StatusCode.Ok)
+                response.body match
+                    case Left(e) => fail(e)
+                    case Right(body) =>
+                        val obtained = body.split("\n").sorted.mkString("\n")
+//                        log.atDebug.log(s"Query results: $obtained")
+                        assertEquals(obtained, expected)
+        )
+    }
+
+    test("count") {
+        val xs = TestUtils.create(2, 2)
+        val expected = 4L
+        val queryRequest = QueryRequest(distinct = Some(true), where = Some(Seq(ConstraintRequest("concept", isnull = Some(false)))))
+        runPost(endpoints.countImpl,
+            s"http://test.com/v1/query/count",
+            queryRequest.stringify,
+            response =>
+//                println(response)
+                assertEquals(response.code, StatusCode.Ok)
+                val obtained = checkResponse[Count](response.body)
+                assertEquals(obtained.count, expected)
+        )
+    }
+
+}

--- a/it/src/main/scala/org/mbari/annosaurus/etc/jdk/Strings.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/etc/jdk/Strings.scala
@@ -18,14 +18,11 @@ package org.mbari.annosaurus.etc.jdk
 
 import scala.util.Random
 
-object Strings {
+object Strings:
 
     private val chars  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
     private val random = new Random
 
-    def random(length: Int): String = {
+    def random(length: Int): String =
         val xs = for (_ <- 0 until length) yield chars.charAt(random.nextInt(chars.length))
         new String(xs.toArray)
-    }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepositorySuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepositorySuite.scala
@@ -17,13 +17,11 @@
 package org.mbari.annosaurus.repository.jdbc
 
 import org.mbari.annosaurus.controllers.TestUtils
-import org.mbari.annosaurus.domain.{ImagedMoment, QueryConstraints}
+import org.mbari.annosaurus.domain.QueryConstraints
 import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
 
-import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-
 import java.time.Instant
+import scala.jdk.CollectionConverters.*
 
 trait AnalysisRepositorySuite extends BaseDAOSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepositorySuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepositorySuite.scala
@@ -41,22 +41,21 @@ trait AnalysisRepositorySuite extends BaseDAOSuite {
     }
 
     test("timeHistogram") {
-        val xs = TestUtils.build(5, 5, includeData = true)
+        val xs    = TestUtils.build(5, 5, includeData = true)
         val start = Instant.parse("1888-08-01T00:00:00Z")
-        for
-            i <- xs.indices
-        do
-            xs(i).setRecordedTimestamp(start.plusSeconds(i * 60 * 60))
-        val dao = daoFactory.newImagedMomentDAO()
+        for i <- xs.indices
+        do xs(i).setRecordedTimestamp(start.plusSeconds(i * 60 * 60))
+        val dao       = daoFactory.newImagedMomentDAO()
         dao.runTransaction(d => xs.foreach(d.create))
-        val minTime  = xs.map(_.getRecordedTimestamp).min
+        val minTime   = xs.map(_.getRecordedTimestamp).min
         val maxTime   = xs.map(_.getRecordedTimestamp).max
 //        xs.foreach(x => println(ImagedMoment.from(x, true).stringify))
         val expected  = xs.flatMap(_.getObservations.asScala).size
         val qcr       = QueryConstraints(
             videoReferenceUuids = Seq(xs.head.getVideoReferenceUuid),
             minTimestamp = Some(minTime.minusSeconds(24 * 60 * 60)),
-            maxTimestamp = Some(maxTime.plusSeconds(24 * 60 * 60)))
+            maxTimestamp = Some(maxTime.plusSeconds(24 * 60 * 60))
+        )
         val histogram = repository.timeHistogram(qcr, 1)
 //        println(histogram)
         assertEquals(histogram.count, expected)

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepositorySuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepositorySuite.scala
@@ -39,22 +39,15 @@ trait AnalysisRepositorySuite extends BaseDAOSuite:
     }
 
     test("timeHistogram") {
-        val xs    = TestUtils.build(5, 5, includeData = true)
-        val start = Instant.parse("1888-08-01T00:00:00Z")
-        for i <- xs.indices
-        do xs(i).setRecordedTimestamp(start.plusSeconds(i * 60 * 60))
-        val dao       = daoFactory.newImagedMomentDAO()
-        dao.runTransaction(d => xs.foreach(d.create))
-        val minTime   = xs.map(_.getRecordedTimestamp).min
-        val maxTime   = xs.map(_.getRecordedTimestamp).max
-//        xs.foreach(x => println(ImagedMoment.from(x, true).stringify))
-        val expected  = xs.flatMap(_.getObservations.asScala).size
-        val qcr       = QueryConstraints(
+        val xs = TestUtils.create(5, 5, includeData = true)
+        val minTime = xs.map(_.getRecordedTimestamp).min
+        val maxTime = xs.map(_.getRecordedTimestamp).max
+        val expected = xs.flatMap(_.getObservations.asScala).size
+        val qcr = QueryConstraints(
             videoReferenceUuids = Seq(xs.head.getVideoReferenceUuid),
             minTimestamp = Some(minTime.minusSeconds(24 * 60 * 60)),
             maxTimestamp = Some(maxTime.plusSeconds(24 * 60 * 60))
         )
         val histogram = repository.timeHistogram(qcr, 1)
-//        println(histogram)
         assertEquals(histogram.count, expected)
     }

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepositorySuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepositorySuite.scala
@@ -39,11 +39,11 @@ trait AnalysisRepositorySuite extends BaseDAOSuite:
     }
 
     test("timeHistogram") {
-        val xs = TestUtils.create(5, 5, includeData = true)
-        val minTime = xs.map(_.getRecordedTimestamp).min
-        val maxTime = xs.map(_.getRecordedTimestamp).max
-        val expected = xs.flatMap(_.getObservations.asScala).size
-        val qcr = QueryConstraints(
+        val xs        = TestUtils.create(5, 5, includeData = true)
+        val minTime   = xs.map(_.getRecordedTimestamp).min
+        val maxTime   = xs.map(_.getRecordedTimestamp).max
+        val expected  = xs.flatMap(_.getObservations.asScala).size
+        val qcr       = QueryConstraints(
             videoReferenceUuids = Seq(xs.head.getVideoReferenceUuid),
             minTimestamp = Some(minTime.minusSeconds(24 * 60 * 60)),
             maxTimestamp = Some(maxTime.plusSeconds(24 * 60 * 60))

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepositorySuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/AnalysisRepositorySuite.scala
@@ -25,7 +25,7 @@ import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 
 import java.time.Instant
 
-trait AnalysisRepositorySuite extends BaseDAOSuite {
+trait AnalysisRepositorySuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -60,5 +60,3 @@ trait AnalysisRepositorySuite extends BaseDAOSuite {
 //        println(histogram)
         assertEquals(histogram.count, expected)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepositorySuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepositorySuite.scala
@@ -16,18 +16,12 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
-import org.mbari.annosaurus.repository.jpa.BaseDAOSuite
 import org.mbari.annosaurus.controllers.TestUtils
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
-import junit.framework.Test
-
-import scala.jdk.CollectionConverters.*
 import org.mbari.annosaurus.domain.{Annotation, ConcurrentRequest, MultiRequest, ObservationsUpdate, QueryConstraints}
+import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
 
 import java.time.Duration
-import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
-import org.checkerframework.checker.units.qual.A
-import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
+import scala.jdk.CollectionConverters.*
 
 trait JdbcRepositorySuite extends BaseDAOSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepositorySuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepositorySuite.scala
@@ -22,20 +22,14 @@ import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import junit.framework.Test
 
 import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.domain.{
-    Annotation,
-    ConcurrentRequest,
-    MultiRequest,
-    ObservationsUpdate,
-    QueryConstraints
-}
+import org.mbari.annosaurus.domain.{Annotation, ConcurrentRequest, MultiRequest, ObservationsUpdate, QueryConstraints}
 
 import java.time.Duration
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
 import org.checkerframework.checker.units.qual.A
 import org.mbari.annosaurus.repository.jpa.entity.ObservationEntity
 
-trait JdbcRepositorySuite extends BaseDAOSuite {
+trait JdbcRepositorySuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -130,26 +124,25 @@ trait JdbcRepositorySuite extends BaseDAOSuite {
         val mr = MultiRequest(Seq(xs.head.getVideoReferenceUuid()))
         val ys = repository.findByMultiRequest(mr, includeAncillaryData = true)
         assertEquals(ys.size, 8)
-        for (y <- ys) {
+        for y <- ys do
             assert(y.ancillaryData.isDefined)
             assertEquals(y.imageReferences.size, 1)
             assertEquals(y.associations.size, 1)
-        }
     }
 
     test("findByQueryConstraint") {
 
         val seed = TestUtils
             .build(50, 1, 1, 1, true)
-            .map(im => {
+            .map(im =>
                 val os = im.getObservations().asScala
-                os.foreach(o => {
+                os.foreach(o =>
                     o.setGroup("group-foo")
                     o.setObserver("observer-foo")
                     o.setActivity("activity-foo")
-                })
+                )
                 im
-            })
+            )
         val xs   = TestUtils.create(seed)
         val ys   = TestUtils.create(50, 1, 1, 1, true)
         val x    = xs.head
@@ -275,11 +268,11 @@ trait JdbcRepositorySuite extends BaseDAOSuite {
         val ts0 = ts.head.minus(Duration.ofSeconds(1))
         val ts1 = ts(2).plus(Duration.ofSeconds(1))
 
-        val expected = xs.filter(im => {
+        val expected = xs.filter(im =>
             val t = im.getRecordedTimestamp()
             im.getVideoReferenceUuid() == x.getVideoReferenceUuid() &&
             t.isAfter(ts0) && t.isBefore(ts1)
-        })
+        )
 
         val obtained =
             repository.findByVideoReferenceUuidAndTimestamps(x.getVideoReferenceUuid(), ts0, ts1)
@@ -340,11 +333,11 @@ trait JdbcRepositorySuite extends BaseDAOSuite {
         val n       = repository.updateObservations(update0)
         assertEquals(n, 0)
 
-        def runUpdate(update: ObservationsUpdate): Unit = {
+        def runUpdate(update: ObservationsUpdate): Unit =
             val n   = repository.updateObservations(update)
             assertEquals(n, xs.size)
             val dao = daoFactory.newObservationDAO()
-            for (uuid <- observationUuids) {
+            for uuid <- observationUuids do
                 val opt = dao.findByUUID(uuid)
                 assert(opt.isDefined)
                 val obs = opt.get
@@ -352,9 +345,7 @@ trait JdbcRepositorySuite extends BaseDAOSuite {
                 update.concept.foreach(c => assertEquals(obs.getConcept, c))
                 update.group.foreach(g => assertEquals(obs.getGroup, g))
                 update.activity.foreach(a => assertEquals(obs.getActivity, a))
-            }
             dao.close()
-        }
 
         val update1 = ObservationsUpdate(observationUuids, concept = Some("concept-foo"))
         runUpdate(update1)
@@ -380,5 +371,3 @@ trait JdbcRepositorySuite extends BaseDAOSuite {
         runUpdate(update5)
 
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepositorySuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/JdbcRepositorySuite.scala
@@ -22,7 +22,13 @@ import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 import junit.framework.Test
 
 import scala.jdk.CollectionConverters.*
-import org.mbari.annosaurus.domain.{Annotation, ConcurrentRequest, MultiRequest, ObservationsUpdate, QueryConstraints}
+import org.mbari.annosaurus.domain.{
+    Annotation,
+    ConcurrentRequest,
+    MultiRequest,
+    ObservationsUpdate,
+    QueryConstraints
+}
 
 import java.time.Duration
 import org.mbari.annosaurus.etc.circe.CirceCodecs.{*, given}
@@ -327,15 +333,15 @@ trait JdbcRepositorySuite extends BaseDAOSuite {
     }
 
     test("updateObservations") {
-        val xs = TestUtils.create(8, 1)
+        val xs               = TestUtils.create(8, 1)
         val observationUuids = xs.map(im => im.getObservations.asScala.head.getUuid())
 
         val update0 = ObservationsUpdate(observationUuids)
-        val n      = repository.updateObservations(update0)
+        val n       = repository.updateObservations(update0)
         assertEquals(n, 0)
 
         def runUpdate(update: ObservationsUpdate): Unit = {
-            val n = repository.updateObservations(update)
+            val n   = repository.updateObservations(update)
             assertEquals(n, xs.size)
             val dao = daoFactory.newObservationDAO()
             for (uuid <- observationUuids) {
@@ -358,21 +364,20 @@ trait JdbcRepositorySuite extends BaseDAOSuite {
         val update2 = ObservationsUpdate(observationUuids, observer = Some("observer-foo"))
         runUpdate(update2)
 
-
         val update3 = ObservationsUpdate(observationUuids, group = Some("group-foo"))
         runUpdate(update3)
 
         val update4 = ObservationsUpdate(observationUuids, activity = Some("activity-foo"))
         runUpdate(update4)
 
-        val update5 = ObservationsUpdate(observationUuids,
+        val update5 = ObservationsUpdate(
+            observationUuids,
             observer = Some("observer-foo2"),
             concept = Some("concept-foo2"),
             group = Some("group-foo2"),
-            activity = Some("activity-foo2"))
+            activity = Some("activity-foo2")
+        )
         runUpdate(update5)
-
-
 
     }
 

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/SqlFileParser.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/SqlFileParser.scala
@@ -16,10 +16,11 @@
 
 package org.mbari.annosaurus.repository.jdbc
 
-import java.sql.Connection
-import java.net.URL
 import jakarta.persistence.EntityManager
 import org.mbari.annosaurus.etc.jdk.Logging.given
+
+import java.net.URL
+import java.sql.Connection
 
 object SqlFileParser:
 

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/SqlFileParser.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jdbc/SqlFileParser.scala
@@ -17,7 +17,7 @@
 package org.mbari.annosaurus.repository.jdbc
 
 import jakarta.persistence.EntityManager
-import org.mbari.annosaurus.etc.jdk.Logging.given
+import org.mbari.annosaurus.etc.jdk.Loggers.given
 
 import java.net.URL
 import java.sql.Connection

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/AssociationDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/AssociationDAOSuite.scala
@@ -16,10 +16,11 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import org.mbari.annosaurus.controllers.TestUtils
-import scala.jdk.CollectionConverters.*
 import org.mbari.annosaurus.AssertUtils
+import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.domain.ConceptAssociationRequest
+
+import scala.jdk.CollectionConverters.*
 
 trait AssociationDAOSuite extends BaseDAOSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/AssociationDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/AssociationDAOSuite.scala
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters.*
 import org.mbari.annosaurus.AssertUtils
 import org.mbari.annosaurus.domain.ConceptAssociationRequest
 
-trait AssociationDAOSuite extends BaseDAOSuite {
+trait AssociationDAOSuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -42,9 +42,7 @@ trait AssociationDAOSuite extends BaseDAOSuite {
         val o                         = i.getObservations.asScala.head
         val a                         = o.getAssociations.asScala.head
         given dao: AssociationDAOImpl = daoFactory.newAssociationDAO()
-        val ys                        = run(() =>
-            dao.findByLinkNameAndVideoReferenceUUID(a.getLinkName, i.getVideoReferenceUuid)
-        )
+        val ys                        = run(() => dao.findByLinkNameAndVideoReferenceUUID(a.getLinkName, i.getVideoReferenceUuid))
         assert(ys.size == 1)
         AssertUtils.assertSameAssociation(a, ys.head)
     }
@@ -142,13 +140,11 @@ trait AssociationDAOSuite extends BaseDAOSuite {
         // correct way to create an association
         given dao: AssociationDAOImpl = daoFactory.newAssociationDAO()
         val obsDao                    = daoFactory.newObservationDAO(dao)
-        run(() => {
+        run(() =>
             obsDao
                 .findByUUID(o.getUuid())
-                .foreach(obs => {
-                    obs.addAssociation(a)
-                })
-        })
+                .foreach(obs => obs.addAssociation(a))
+        )
         val ys                        = run(() => dao.findByUUID(a.getUuid()))
         assert(ys.isDefined)
         AssertUtils.assertSameAssociation(ys.get, a)
@@ -173,10 +169,9 @@ trait AssociationDAOSuite extends BaseDAOSuite {
         val a                         = o.getAssociations().asScala.head
         given dao: AssociationDAOImpl = daoFactory.newAssociationDAO()
         run(() =>
-            dao.findByUUID(a.getUuid()) match {
+            dao.findByUUID(a.getUuid()) match
                 case Some(x) => dao.delete(x)
                 case None    => fail("Could not find association")
-            }
         )
         val ys                        = run(() => dao.findByUUID(a.getUuid()))
         assert(ys.isEmpty)
@@ -202,5 +197,3 @@ trait AssociationDAOSuite extends BaseDAOSuite {
         assert(ys.isDefined)
         AssertUtils.assertSameAssociation(ys.get, a)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAOSuite.scala
@@ -37,4 +37,4 @@ trait BaseDAOSuite extends munit.FunSuite:
 
     override def afterEach(context: AfterEach): Unit =
         super.afterEach(context)
-    daoFactory.cleanup()
+        daoFactory.cleanup()

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAOSuite.scala
@@ -19,9 +19,7 @@ package org.mbari.annosaurus.repository.jpa
 import org.mbari.annosaurus.repository.DAO
 
 import java.time.Duration
-import java.util.concurrent.TimeUnit
 import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.concurrent.duration.Duration as SDuration
 import scala.jdk.DurationConverters.*
 
 trait BaseDAOSuite extends munit.FunSuite:

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/BaseDAOSuite.scala
@@ -24,7 +24,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration as SDuration
 import scala.jdk.DurationConverters.*
 
-trait BaseDAOSuite extends munit.FunSuite {
+trait BaseDAOSuite extends munit.FunSuite:
 
     given ec: ExecutionContext = ExecutionContext.global
 
@@ -40,4 +40,3 @@ trait BaseDAOSuite extends munit.FunSuite {
     override def afterEach(context: AfterEach): Unit =
         super.afterEach(context)
     daoFactory.cleanup()
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedAncillaryDatumDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedAncillaryDatumDAOSuite.scala
@@ -20,7 +20,7 @@ import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.AssertUtils
 import org.mbari.annosaurus.domain.CachedAncillaryDatum
 
-trait CachedAncillaryDatumDAOSuite extends BaseDAOSuite {
+trait CachedAncillaryDatumDAOSuite extends BaseDAOSuite:
     given JPADAOFactory = daoFactory
 
     test("findByUUID") {
@@ -48,14 +48,13 @@ trait CachedAncillaryDatumDAOSuite extends BaseDAOSuite {
         given dao: CachedAncillaryDatumDAOImpl = daoFactory.newCachedAncillaryDatumDAO()
         val imDao                              = daoFactory.newImagedMomentDAO(dao)
         val d                                  = TestUtils.randomData()
-        run(() => {
+        run(() =>
             imDao.findByUUID(im.getUuid()) match
                 case Some(im0) =>
                     im0.setAncillaryDatum(d)
                 // dao.create(d) // Not needed as adding to imagedmoment in transaction will persist the datum
                 case None      => fail("Failed to find imaged moment")
-
-        })
+        )
         run(() => dao.findByUUID(d.getUuid())) match
             case Some(d1) => AssertUtils.assertSameAncillaryDatum(d1, d)
             case None     => fail("Failed to find ancillary datum")
@@ -79,11 +78,11 @@ trait CachedAncillaryDatumDAOSuite extends BaseDAOSuite {
         val im                                 = TestUtils.create(1, 1, 1, 1, true).head
         val d                                  = im.getAncillaryDatum()
         given dao: CachedAncillaryDatumDAOImpl = daoFactory.newCachedAncillaryDatumDAO()
-        run(() => {
+        run(() =>
             dao.findByUUID(d.getUuid()) match
                 case Some(a) => dao.delete(a)
                 case None    => fail("Failed to find ancillary datum")
-        })
+        )
         val ys                                 = run(() => dao.findByUUID(d.getUuid()))
         dao.close()
         assert(ys.isEmpty)
@@ -146,5 +145,3 @@ trait CachedAncillaryDatumDAOSuite extends BaseDAOSuite {
         dao.close()
         assert(ys.size == 0)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedAncillaryDatumDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedAncillaryDatumDAOSuite.scala
@@ -16,8 +16,8 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.AssertUtils
+import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.domain.CachedAncillaryDatum
 
 trait CachedAncillaryDatumDAOSuite extends BaseDAOSuite:

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOSuite.scala
@@ -16,9 +16,8 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.AssertUtils
-import org.mbari.annosaurus.domain.CachedVideoReferenceInfo
+import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.repository.jpa.entity.CachedVideoReferenceInfoEntity
 
 trait CachedVideoReferenceInfoDAOSuite extends BaseDAOSuite:

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/CachedVideoReferenceInfoDAOSuite.scala
@@ -21,7 +21,7 @@ import org.mbari.annosaurus.AssertUtils
 import org.mbari.annosaurus.domain.CachedVideoReferenceInfo
 import org.mbari.annosaurus.repository.jpa.entity.CachedVideoReferenceInfoEntity
 
-trait CachedVideoReferenceInfoDAOSuite extends BaseDAOSuite {
+trait CachedVideoReferenceInfoDAOSuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -33,14 +33,13 @@ trait CachedVideoReferenceInfoDAOSuite extends BaseDAOSuite {
         assert(vi.getUuid() != null)
     }
 
-    def createTestData(): CachedVideoReferenceInfoEntity = {
+    def createTestData(): CachedVideoReferenceInfoEntity =
         val vi                                     = TestUtils.randomVideoReferenceInfo()
         given dao: CachedVideoReferenceInfoDAOImpl = daoFactory.newCachedVideoReferenceInfoDAO()
         run(() => dao.create(vi))
         dao.close()
         vi
 
-    }
     test("update") {
         val vi                                     = createTestData()
         given dao: CachedVideoReferenceInfoDAOImpl = daoFactory.newCachedVideoReferenceInfoDAO()
@@ -55,10 +54,10 @@ trait CachedVideoReferenceInfoDAOSuite extends BaseDAOSuite {
     test("delete") {
         val vi                                     = createTestData()
         given dao: CachedVideoReferenceInfoDAOImpl = daoFactory.newCachedVideoReferenceInfoDAO()
-        run(() => {
+        run(() =>
             // update brings entity into transactional context
             dao.delete(dao.update(vi))
-        })
+        )
         run(() => dao.findByUUID(vi.getUuid())) match
             case None        => // ok
             case Some(value) => fail("should not have found the entity")
@@ -167,5 +166,3 @@ trait CachedVideoReferenceInfoDAOSuite extends BaseDAOSuite {
         assert(xs.contains(vi.getMissionId()))
         dao.close()
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ImageReferenceDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ImageReferenceDAOSuite.scala
@@ -16,9 +16,10 @@
 
 package org.mbari.annosaurus.repository.jpa
 
+import org.mbari.annosaurus.AssertUtils
 import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
-import org.mbari.annosaurus.AssertUtils
+
 import java.net.URI
 
 trait ImageReferenceDAOSuite extends BaseDAOSuite:

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ImageReferenceDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ImageReferenceDAOSuite.scala
@@ -21,7 +21,7 @@ import org.mbari.annosaurus.repository.jpa.entity.ImageReferenceEntity
 import org.mbari.annosaurus.AssertUtils
 import java.net.URI
 
-trait ImageReferenceDAOSuite extends BaseDAOSuite {
+trait ImageReferenceDAOSuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -30,11 +30,11 @@ trait ImageReferenceDAOSuite extends BaseDAOSuite {
         val ir                           = TestUtils.randomImageReference()
         given dao: ImageReferenceDAOImpl = daoFactory.newImageReferenceDAO()
         val imDao                        = daoFactory.newImagedMomentDAO(dao)
-        run(() => {
+        run(() =>
             val im1 = imDao.update(im)
             im1.addImageReference(ir)
             // dao.create(ir)
-        })
+        )
         run(() => dao.findByUUID(ir.getUuid())) match
             case Some(ir1) => AssertUtils.assertSameImageReference(ir1, ir)
             case None      => fail("Failed to find image reference")
@@ -57,12 +57,12 @@ trait ImageReferenceDAOSuite extends BaseDAOSuite {
         val im                           = TestUtils.create(1, nImageReferences = 1).head
         val ir                           = im.getImageReferences.iterator().next()
         given dao: ImageReferenceDAOImpl = daoFactory.newImageReferenceDAO()
-        run(() => {
+        run(() =>
             // update brings entity into transactional context
             val ir0 = dao.update(ir)
             ir0.getImagedMoment().removeImageReference(ir0)
             // dao.delete(ir0) // Not needed as removing from imagedmoment in transaction will remove the image reference
-        })
+        )
         run(() => dao.findByUUID(ir.getUuid())) match
             case Some(_) => fail("should not have found the entity")
             case None    => // good
@@ -122,5 +122,3 @@ trait ImageReferenceDAOSuite extends BaseDAOSuite {
         AssertUtils.assertSameImageReference(xs.head, ir)
         dao.close()
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOSuite.scala
@@ -28,7 +28,7 @@ import org.mbari.annosaurus.AssertUtils
 import scala.jdk.CollectionConverters.*
 import org.mbari.annosaurus.domain.WindowRequest
 
-trait ImagedMomentDAOSuite extends BaseDAOSuite {
+trait ImagedMomentDAOSuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -89,12 +89,11 @@ trait ImagedMomentDAOSuite extends BaseDAOSuite {
         given dao: ImagedMomentDAOImpl = daoFactory.newImagedMomentDAO()
         val opt0                       = run(() => dao.findByUUID(im0.getUuid()))
         assert(opt0.isDefined)
-        run(() => {
-            dao.findByUUID(im0.getUuid()) match {
+        run(() =>
+            dao.findByUUID(im0.getUuid()) match
                 case Some(x) => dao.delete(x)
                 case None    => fail("Could not find imaged moment")
-            }
-        })
+        )
         val opt1                       = run(() => dao.findByUUID(im0.getUuid()))
         assert(opt1.isEmpty)
     }
@@ -302,9 +301,7 @@ trait ImagedMomentDAOSuite extends BaseDAOSuite {
         val xs                         = TestUtils.create(1)
         given dao: ImagedMomentDAOImpl = daoFactory.newImagedMomentDAO()
         val t                          = xs.head.getRecordedTimestamp()
-        val opt                        = run(() =>
-            dao.findByVideoReferenceUUIDAndRecordedDate(xs.head.getVideoReferenceUuid(), t)
-        )
+        val opt                        = run(() => dao.findByVideoReferenceUUIDAndRecordedDate(xs.head.getVideoReferenceUuid(), t))
         assert(opt.isDefined)
         AssertUtils.assertSameImagedMoment(opt.get, xs.head)
     }
@@ -313,9 +310,7 @@ trait ImagedMomentDAOSuite extends BaseDAOSuite {
         val xs                         = TestUtils.create(1)
         given dao: ImagedMomentDAOImpl = daoFactory.newImagedMomentDAO()
         val t                          = xs.head.getElapsedTime()
-        val opt                        = run(() =>
-            dao.findByVideoReferenceUUIDAndElapsedTime(xs.head.getVideoReferenceUuid(), t)
-        )
+        val opt                        = run(() => dao.findByVideoReferenceUUIDAndElapsedTime(xs.head.getVideoReferenceUuid(), t))
         assert(opt.isDefined)
         AssertUtils.assertSameImagedMoment(opt.get, xs.head)
     }
@@ -339,9 +334,7 @@ trait ImagedMomentDAOSuite extends BaseDAOSuite {
         run(() => dao.update(im0))
 
         val timecode = im0.getTimecode()
-        val im1      = run(() =>
-            dao.findByVideoReferenceUUIDAndIndex(im0.getVideoReferenceUuid(), Some(timecode))
-        )
+        val im1      = run(() => dao.findByVideoReferenceUUIDAndIndex(im0.getVideoReferenceUuid(), Some(timecode)))
         assert(im1.isDefined)
         AssertUtils.assertSameImagedMoment(im1.get, im0)
 
@@ -440,5 +433,3 @@ trait ImagedMomentDAOSuite extends BaseDAOSuite {
         val im4 = run(() => dao.findByUUID(im3.getUuid()))
         assert(im4.isEmpty)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ImagedMomentDAOSuite.scala
@@ -16,17 +16,14 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import jakarta.persistence.EntityManager
-import java.util.UUID
-import org.mbari.vcr4j.time.Timecode
-import java.time.Duration
-import java.time.Instant
-import junit.framework.Test
-import org.mbari.annosaurus.controllers.TestUtils
-import junit.framework.Assert
 import org.mbari.annosaurus.AssertUtils
-import scala.jdk.CollectionConverters.*
+import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.domain.WindowRequest
+import org.mbari.vcr4j.time.Timecode
+
+import java.time.{Duration, Instant}
+import java.util.UUID
+import scala.jdk.CollectionConverters.*
 
 trait ImagedMomentDAOSuite extends BaseDAOSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/IndexDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/IndexDAOSuite.scala
@@ -23,7 +23,7 @@ import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.AssertUtils
 import org.mbari.annosaurus.controllers.TestUtils.create
 
-trait IndexDAOSuite extends BaseDAOSuite {
+trait IndexDAOSuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -140,5 +140,3 @@ trait IndexDAOSuite extends BaseDAOSuite {
         AssertUtils.assertSameIndex(opt.get, idx)
         dao.close()
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/IndexDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/IndexDAOSuite.scala
@@ -16,12 +16,10 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
-import java.util.UUID
-import org.mbari.vcr4j.time.Timecode
-import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.AssertUtils
-import org.mbari.annosaurus.controllers.TestUtils.create
+import org.mbari.annosaurus.controllers.TestUtils
+import org.mbari.annosaurus.repository.jpa.entity.IndexEntity
+import org.mbari.vcr4j.time.Timecode
 
 trait IndexDAOSuite extends BaseDAOSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOSuite.scala
@@ -16,12 +16,11 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.AssertUtils
+import org.mbari.annosaurus.controllers.TestUtils
+import org.mbari.annosaurus.domain.{ConcurrentRequest, MultiRequest}
+
 import java.time.Duration
-import org.checkerframework.checker.units.qual.C
-import org.mbari.annosaurus.domain.ConcurrentRequest
-import org.mbari.annosaurus.domain.MultiRequest
 import scala.jdk.CollectionConverters.*
 
 trait ObservationDAOSuite extends BaseDAOSuite:

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOSuite.scala
@@ -151,24 +151,26 @@ trait ObservationDAOSuite extends BaseDAOSuite:
 
     test("findAllGroups") {
         val xs                        = TestUtils.create(5, 1)
-        val expected            =  xs.flatMap(_.getObservations().asScala.map(_.getGroup()))
+        val expected                  = xs
+            .flatMap(_.getObservations().asScala.map(_.getGroup()))
             .filter(_ != null)
             .distinct
             .sorted
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
-        val obtained                    = run(() => dao.findAllGroups()).sorted
+        val obtained                  = run(() => dao.findAllGroups()).sorted
         assertEquals(obtained, expected)
         dao.close()
     }
 
     test("findAllActivities") {
         val xs                        = TestUtils.create(5, 1)
-        val expected        = xs.flatMap(_.getObservations.asScala.map(_.getActivity()))
-                .filter(_ != null)
-                .distinct
-                .sorted
+        val expected                  = xs
+            .flatMap(_.getObservations.asScala.map(_.getActivity()))
+            .filter(_ != null)
+            .distinct
+            .sorted
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
-        val obtained                = run(() => dao.findAllActivities()).sorted
+        val obtained                  = run(() => dao.findAllActivities()).sorted
         assertEquals(obtained, expected)
         dao.close()
     }

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOSuite.scala
@@ -151,23 +151,25 @@ trait ObservationDAOSuite extends BaseDAOSuite:
 
     test("findAllGroups") {
         val xs                        = TestUtils.create(5, 1)
-        val existingGroups            =
-            xs.flatMap(_.getObservations().asScala.map(_.getGroup())).filter(_ != null)
+        val expected            =  xs.flatMap(_.getObservations().asScala.map(_.getGroup()))
+            .filter(_ != null)
+            .distinct
+            .sorted
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
-        val groups                    = run(() => dao.findAllGroups())
-        assert(groups.size >= xs.size)
-        for g <- existingGroups do assert(groups.contains(g))
+        val obtained                    = run(() => dao.findAllGroups()).sorted
+        assertEquals(obtained, expected)
         dao.close()
     }
 
     test("findAllActivities") {
         val xs                        = TestUtils.create(5, 1)
-        val existingActivities        =
-            xs.flatMap(_.getObservations().asScala.map(_.getActivity())).filter(_ != null)
+        val expected        = xs.flatMap(_.getObservations.asScala.map(_.getActivity()))
+                .filter(_ != null)
+                .distinct
+                .sorted
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
-        val activities                = run(() => dao.findAllActivities())
-        assert(activities.size >= xs.size)
-        for a <- existingActivities do assert(activities.contains(a))
+        val obtained                = run(() => dao.findAllActivities()).sorted
+        assertEquals(obtained, expected)
         dao.close()
     }
 

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/ObservationDAOSuite.scala
@@ -24,7 +24,7 @@ import org.mbari.annosaurus.domain.ConcurrentRequest
 import org.mbari.annosaurus.domain.MultiRequest
 import scala.jdk.CollectionConverters.*
 
-trait ObservationDAOSuite extends BaseDAOSuite {
+trait ObservationDAOSuite extends BaseDAOSuite:
     given JPADAOFactory = daoFactory
 
     test("create") {
@@ -32,10 +32,10 @@ trait ObservationDAOSuite extends BaseDAOSuite {
         val obs                       = TestUtils.randomObservation()
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
         val imDao                     = daoFactory.newImagedMomentDAO(dao)
-        run(() => {
+        run(() =>
             val im0 = imDao.update(im)
             im0.addObservation(obs)
-        })
+        )
         run(() => dao.findByUUID(obs.getUuid())) match
             case None        => fail("should have found the entity")
             case Some(value) => AssertUtils.assertSameObservation(value, obs)
@@ -58,11 +58,11 @@ trait ObservationDAOSuite extends BaseDAOSuite {
         val im                        = TestUtils.create(1, 1).head
         val obs                       = im.getObservations().iterator().next()
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
-        run(() => {
+        run(() =>
             val obs0 = dao.update(obs)
             obs0.getImagedMoment().removeObservation(obs0)
             // dao.delete(obs0) // DOn't call delete, just remove from parent
-        })
+        )
         run(() => dao.findByUUID(obs.getUuid())) match
             case None        => // OK
             case Some(value) => fail("should not have found the entity")
@@ -73,9 +73,7 @@ trait ObservationDAOSuite extends BaseDAOSuite {
         val im                        = TestUtils.create(1, 1).head
         val obs                       = im.getObservations().iterator().next()
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
-        run(() => {
-            dao.deleteByUUID(obs.getUuid())
-        })
+        run(() => dao.deleteByUUID(obs.getUuid()))
         run(() => dao.findByUUID(obs.getUuid())) match
             case None        => // OK
             case Some(value) => fail("should not have found the entity")
@@ -148,7 +146,7 @@ trait ObservationDAOSuite extends BaseDAOSuite {
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
         val concepts                  = run(() => dao.findAllConcepts())
         assert(concepts.size >= xs.size)
-        for (c <- existingConcepts) assert(concepts.contains(c))
+        for c <- existingConcepts do assert(concepts.contains(c))
         dao.close()
     }
 
@@ -159,7 +157,7 @@ trait ObservationDAOSuite extends BaseDAOSuite {
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
         val groups                    = run(() => dao.findAllGroups())
         assert(groups.size >= xs.size)
-        for (g <- existingGroups) assert(groups.contains(g))
+        for g <- existingGroups do assert(groups.contains(g))
         dao.close()
     }
 
@@ -170,7 +168,7 @@ trait ObservationDAOSuite extends BaseDAOSuite {
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
         val activities                = run(() => dao.findAllActivities())
         assert(activities.size >= xs.size)
-        for (a <- existingActivities) assert(activities.contains(a))
+        for a <- existingActivities do assert(activities.contains(a))
         dao.close()
     }
 
@@ -190,10 +188,9 @@ trait ObservationDAOSuite extends BaseDAOSuite {
         val xs                        = TestUtils.create(5, 1)
         val existingConcepts          = xs.flatMap(_.getObservations().asScala.map(_.getConcept()))
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
-        for (c <- existingConcepts) {
+        for c <- existingConcepts do
             val count = run(() => dao.countByConcept(c))
             assert(count == 1)
-        }
         dao.close()
     }
 
@@ -201,17 +198,15 @@ trait ObservationDAOSuite extends BaseDAOSuite {
         val xs                        = TestUtils.create(3, 1)
         val existingConcepts          = xs.flatMap(_.getObservations().asScala.map(_.getConcept()))
         given dao: ObservationDAOImpl = daoFactory.newObservationDAO()
-        for (c <- existingConcepts) {
+        for c <- existingConcepts do
             val count = run(() => dao.countByConceptWithImages(c))
             assert(count == 0)
-        }
 
         val ys                = TestUtils.create(3, 1, 0, 1)
         val existingConcepts2 = ys.flatMap(_.getObservations().asScala.map(_.getConcept()))
-        for (c <- existingConcepts2) {
+        for c <- existingConcepts2 do
             val count = run(() => dao.countByConceptWithImages(c))
             assert(count == 1)
-        }
         dao.close()
     }
 
@@ -267,5 +262,3 @@ trait ObservationDAOSuite extends BaseDAOSuite {
         dao.close()
 
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactory.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactory.scala
@@ -17,12 +17,10 @@
 package org.mbari.annosaurus.repository.jpa
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.mbari.annosaurus.repository.jpa.JPADAOFactory
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import org.mbari.annosaurus.repository.jpa.EntityManagerFactories
 
 trait TestDAOFactory extends JPADAOFactory:
 

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactory.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactory.scala
@@ -17,6 +17,7 @@
 package org.mbari.annosaurus.repository.jpa
 
 import com.typesafe.config.{Config, ConfigFactory}
+import org.mbari.annosaurus.DatabaseConfig
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
@@ -42,6 +43,10 @@ trait TestDAOFactory extends JPADAOFactory:
         Await.result(f, Duration(60, TimeUnit.SECONDS))
 
     def testProps(): Map[String, String]
+    
+    def databaseConfig: DatabaseConfig
+    
+    val annotationView: String = "annotations"
 
 object TestDAOFactory:
     val TestProperties = EntityManagerFactories.PRODUCTION_PROPS ++ Map(

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactory.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactory.scala
@@ -24,14 +24,14 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import org.mbari.annosaurus.repository.jpa.EntityManagerFactories
 
-trait TestDAOFactory extends JPADAOFactory {
+trait TestDAOFactory extends JPADAOFactory:
 
     lazy val config: Config = ConfigFactory.load()
 
     def beforeAll(): Unit = ()
     def afterAll(): Unit  = ()
 
-    def cleanup(): Unit = {
+    def cleanup(): Unit =
 
         import scala.concurrent.ExecutionContext.Implicits.global
         val dao = newImagedMomentDAO()
@@ -42,14 +42,11 @@ trait TestDAOFactory extends JPADAOFactory {
         }
         f.onComplete(t => dao.close())
         Await.result(f, Duration(60, TimeUnit.SECONDS))
-    }
 
     def testProps(): Map[String, String]
-}
 
-object TestDAOFactory {
+object TestDAOFactory:
     val TestProperties = EntityManagerFactories.PRODUCTION_PROPS ++ Map(
         "jakarta.persistence.schema-generation.scripts.create-target" -> "target/test-database-create.ddl",
         "jakarta.persistence.schema-generation.scripts.drop-target"   -> "target/test-database-drop.ddl"
     )
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactory.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactory.scala
@@ -43,9 +43,9 @@ trait TestDAOFactory extends JPADAOFactory:
         Await.result(f, Duration(60, TimeUnit.SECONDS))
 
     def testProps(): Map[String, String]
-    
+
     def databaseConfig: DatabaseConfig
-    
+
     val annotationView: String = "annotations"
 
 object TestDAOFactory:

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactorySuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactorySuite.scala
@@ -23,7 +23,7 @@ import java.util.UUID
 import org.hibernate.Session
 import org.hibernate.jdbc.Work
 
-trait TestDAOFactorySuite extends BaseDAOSuite {
+trait TestDAOFactorySuite extends BaseDAOSuite:
 
     test("DAOFactory connects to database") {
         val dao = daoFactory.newImagedMomentDAO();
@@ -53,7 +53,7 @@ trait TestDAOFactorySuite extends BaseDAOSuite {
         tx.begin();
 
         val session = em.unwrap(classOf[Session]);
-        session.doWork(connection => {
+        session.doWork(connection =>
             val statement = connection.createStatement()
             val rs        = statement.executeQuery(
                 s"select uuid from imaged_moments where uuid = '${im.getUuid()}'"
@@ -62,11 +62,9 @@ trait TestDAOFactorySuite extends BaseDAOSuite {
             val uuid      = UUID.fromString(rs.getString("uuid"))
 //            println(s"uuid: $uuid  ---- ${im.getUuid()}")
             assert(uuid == im.getUuid())
-        })
+        )
 
         tx.commit()
         dao.close()
 
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactorySuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/jpa/TestDAOFactorySuite.scala
@@ -16,12 +16,11 @@
 
 package org.mbari.annosaurus.repository.jpa
 
-import org.mbari.annosaurus.controllers.TestUtils
-import java.sql.DriverManager
-import scala.jdk.CollectionConverters.*
-import java.util.UUID
 import org.hibernate.Session
 import org.hibernate.jdbc.Work
+import org.mbari.annosaurus.controllers.TestUtils
+
+import java.util.UUID
 
 trait TestDAOFactorySuite extends BaseDAOSuite:
 

--- a/it/src/main/scala/org/mbari/annosaurus/repository/query/QueryServiceSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/query/QueryServiceSuite.scala
@@ -20,7 +20,7 @@ import org.mbari.annosaurus.controllers.TestUtils
 import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
 import org.mbari.annosaurus.repository.query.Constraint.In
 
-trait QueryServiceSuite extends BaseDAOSuite {
+trait QueryServiceSuite extends BaseDAOSuite:
 
     given JPADAOFactory = daoFactory
 
@@ -33,10 +33,10 @@ trait QueryServiceSuite extends BaseDAOSuite {
     }
 
     test("query distinct concept") {
-        val im = TestUtils.create(5, 2, 1)
+        val im    = TestUtils.create(5, 2, 1)
         val query = Query(select = Seq("concept"), distinct = true)
         queryService.query(query) match
-            case Left(e) => fail(e.getMessage)
+            case Left(e)        => fail(e.getMessage)
             case Right(results) =>
                 assertEquals(results.size, 1)
                 assertEquals(results.head._2.size, 10)
@@ -44,23 +44,25 @@ trait QueryServiceSuite extends BaseDAOSuite {
     }
 
     test("query distinct concept with limit") {
-        val im = TestUtils.create(5, 2, 1)
+        val im    = TestUtils.create(5, 2, 1)
         val query = Query(select = Seq("concept"), distinct = true, limit = Some(2))
         queryService.query(query) match
-            case Left(e) => fail(e.getMessage)
+            case Left(e)        => fail(e.getMessage)
             case Right(results) =>
                 assertEquals(results.size, 1)
                 assertEquals(results.head._2.size, 2)
     }
 
     test("query by concept") {
-        val im = TestUtils.create(5, 2, 1)
-        val query = Query(select = Seq("concept"), distinct = true, where = Seq(In("concept", Seq(im.head.getObservations.iterator().next().getConcept))))
+        val im    = TestUtils.create(5, 2, 1)
+        val query = Query(
+            select = Seq("concept"),
+            distinct = true,
+            where = Seq(In("concept", Seq(im.head.getObservations.iterator().next().getConcept)))
+        )
         queryService.query(query) match
-            case Left(e) => fail(e.getMessage)
+            case Left(e)        => fail(e.getMessage)
             case Right(results) =>
                 assertEquals(results.size, 1)
                 assertEquals(results.head._2.size, 1)
     }
-
-}

--- a/it/src/main/scala/org/mbari/annosaurus/repository/query/QueryServiceSuite.scala
+++ b/it/src/main/scala/org/mbari/annosaurus/repository/query/QueryServiceSuite.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Monterey Bay Aquarium Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mbari.annosaurus.repository.query
+
+import org.mbari.annosaurus.controllers.TestUtils
+import org.mbari.annosaurus.repository.jpa.{BaseDAOSuite, JPADAOFactory}
+import org.mbari.annosaurus.repository.query.Constraint.In
+
+trait QueryServiceSuite extends BaseDAOSuite {
+
+    given JPADAOFactory = daoFactory
+
+    lazy val queryService = new QueryService(daoFactory.databaseConfig, daoFactory.annotationView)
+
+    test("connection") {
+        val d = daoFactory.databaseConfig
+        val c = d.newConnection()
+        c.close()
+    }
+
+    test("query distinct concept") {
+        val im = TestUtils.create(5, 2, 1)
+        val query = Query(select = Seq("concept"), distinct = true)
+        queryService.query(query) match
+            case Left(e) => fail(e.getMessage)
+            case Right(results) =>
+                assertEquals(results.size, 1)
+                assertEquals(results.head._2.size, 10)
+
+    }
+
+    test("query distinct concept with limit") {
+        val im = TestUtils.create(5, 2, 1)
+        val query = Query(select = Seq("concept"), distinct = true, limit = Some(2))
+        queryService.query(query) match
+            case Left(e) => fail(e.getMessage)
+            case Right(results) =>
+                assertEquals(results.size, 1)
+                assertEquals(results.head._2.size, 2)
+    }
+
+    test("query by concept") {
+        val im = TestUtils.create(5, 2, 1)
+        val query = Query(select = Seq("concept"), distinct = true, where = Seq(In("concept", Seq(im.head.getObservations.iterator().next().getConcept))))
+        queryService.query(query) match
+            case Left(e) => fail(e.getMessage)
+            case Right(results) =>
+                assertEquals(results.size, 1)
+                assertEquals(results.head._2.size, 1)
+    }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ object Dependencies {
 
     lazy val auth0 = "com.auth0" % "java-jwt" % "4.4.0"
 
-    val circeVersion      = "0.14.9"
+    val circeVersion      = "0.14.10"
     lazy val circeCore    = "io.circe" %% "circe-core"    % circeVersion
     lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
     lazy val circeParser  = "io.circe" %% "circe-parser"  % circeVersion
@@ -25,7 +25,7 @@ object Dependencies {
     lazy val gson             = "com.google.code.gson" % "gson"              % "2.10.1"
     lazy val h2               = "com.h2database"       % "h2"                % "2.3.232"
 
-    val hibernateVersion     = "6.6.0.Final"  //"6.4.8.Final" //"6.5.1.Final" - envers is throwing: The column name REV is not valid. 
+    val hibernateVersion     = "6.6.1.Final"  //"6.4.8.Final" //"6.5.1.Final" - envers is throwing: The column name REV is not valid.
     lazy val hibernateCore   = "org.hibernate.orm" % "hibernate-core"     % hibernateVersion
     lazy val hibernateEnvers = "org.hibernate.orm" % "hibernate-envers"   % hibernateVersion
     lazy val hibernateHikari = "org.hibernate.orm" % "hibernate-hikaricp" % hibernateVersion
@@ -49,12 +49,12 @@ object Dependencies {
     lazy val json4sJackson = "org.json4s"         %% "json4s-jackson"  % "4.0.7"
     lazy val junit         = "junit"               % "junit"           % "4.13.2"
 
-    val logbackVersion      = "1.5.7"
+    val logbackVersion      = "1.5.10"
     lazy val logbackClassic = "ch.qos.logback" % "logback-classic" % logbackVersion
     lazy val logbackCore    = "ch.qos.logback" % "logback-core"    % logbackVersion
 
     lazy val mssqlserver = "com.microsoft.sqlserver" % "mssql-jdbc" % "12.8.1.jre11"
-    lazy val munit       = "org.scalameta"          %% "munit"      % "1.0.1"
+    lazy val munit       = "org.scalameta"          %% "munit"      % "1.0.2"
     lazy val oracle      = "com.oracle.ojdbc"        % "ojdbc8"     % "19.3.0.0"
     lazy val postgresql  = "org.postgresql"          % "postgresql" % "42.7.4"
     lazy val rxJava3     = "io.reactivex.rxjava3"    % "rxjava"     % "3.1.9"
@@ -73,7 +73,7 @@ object Dependencies {
     lazy val slf4jLog4j = "org.slf4j" % "log4j-over-slf4j" % slf4jVersion
     lazy val slf4jSystem = "org.slf4j" % "slf4j-jdk-platform-logging" % slf4jVersion
 
-    private val tapirVersion = "1.11.1"
+    private val tapirVersion = "1.11.7"
     lazy val tapirCirce      = "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"         % tapirVersion
     lazy val tapirHelidon    = "com.softwaremill.sttp.tapir"   %% "tapir-nima-server"        % tapirVersion
     lazy val tapirPrometheus = "com.softwaremill.sttp.tapir"   %% "tapir-prometheus-metrics" % tapirVersion
@@ -81,7 +81,7 @@ object Dependencies {
     lazy val tapirSwagger    = "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"  % tapirVersion
     lazy val tapirVertex     = "com.softwaremill.sttp.tapir"   %% "tapir-vertx-server"       % tapirVersion
 
-    lazy val tapirSttpCirce  = "com.softwaremill.sttp.client3" %% "circe"                    % "3.9.8"
+    lazy val tapirSttpCirce  = "com.softwaremill.sttp.client3" %% "circe"                    % "3.10.0"
 
     // val testcontainersScalaVersion = "0.41.0"
     // lazy val testcontainersPostgresql =
@@ -93,7 +93,7 @@ object Dependencies {
     // lazy val testcontainersSqlserver =
     //   "com.dimafeng" %% "testcontainers-scala-mssqlserver" % testcontainersScalaVersion
 
-    val testcontainersVersion        = "1.20.1"
+    val testcontainersVersion        = "1.20.2"
     lazy val testcontainersCore      = "org.testcontainers" % "testcontainers" % testcontainersVersion
     lazy val testcontainersSqlserver = "org.testcontainers" % "mssqlserver"    % testcontainersVersion
     lazy val testcontainersOracle    = "org.testcontainers" % "oracle-xe"      % testcontainersVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,7 +81,7 @@ object Dependencies {
     lazy val tapirSwagger    = "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"  % tapirVersion
     lazy val tapirVertex     = "com.softwaremill.sttp.tapir"   %% "tapir-vertx-server"       % tapirVersion
 
-    lazy val tapirSttpCirce  = "com.softwaremill.sttp.client3" %% "circe"                    % "3.10.0"
+    lazy val tapirSttpCirce  = "com.softwaremill.sttp.client3" %% "circe"                    % "3.10.1"
 
     // val testcontainersScalaVersion = "0.41.0"
     // lazy val testcontainersPostgresql =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
     lazy val hibernateEnvers = "org.hibernate.orm" % "hibernate-envers"   % hibernateVersion
     lazy val hibernateHikari = "org.hibernate.orm" % "hibernate-hikaricp" % hibernateVersion
 
-    lazy val hikariCp         = "com.zaxxer"           % "HikariCP"          % "5.1.0"
+    lazy val hikariCp         = "com.zaxxer"           % "HikariCP"          % "6.0.0"
     lazy val jansi            = "org.fusesource.jansi" % "jansi"             % "2.4.1"
     lazy val javaxServlet     = "javax.servlet"        % "javax.servlet-api" % "4.0.1"
     lazy val javaxTransaction = "javax.transaction"    % "jta"               % "1.1"
@@ -49,7 +49,7 @@ object Dependencies {
     lazy val json4sJackson = "org.json4s"         %% "json4s-jackson"  % "4.0.7"
     lazy val junit         = "junit"               % "junit"           % "4.13.2"
 
-    val logbackVersion      = "1.5.10"
+    val logbackVersion      = "1.5.11"
     lazy val logbackClassic = "ch.qos.logback" % "logback-classic" % logbackVersion
     lazy val logbackCore    = "ch.qos.logback" % "logback-core"    % logbackVersion
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.10.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"         % "0.6.4")
-addSbtPlugin("com.github.sbt"    % "sbt-git"             % "2.0.1")
+addSbtPlugin("com.github.sbt"    % "sbt-git"             % "2.1.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"          % "5.10.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"        % "2.5.2")
 addSbtPlugin("com.codecommit"    % "sbt-github-packages" % "0.5.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,9 @@
-addSbtPlugin("com.timushev.sbt"  % "sbt-updates"         % "0.6.4")
+addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"        % "0.13.0")
+addSbtPlugin("com.codecommit"    % "sbt-github-packages" % "0.5.3")
 addSbtPlugin("com.github.sbt"    % "sbt-git"             % "2.1.0")
+addSbtPlugin("com.github.sbt"    % "sbt-native-packager" % "1.10.4")
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates"         % "0.6.4")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"          % "5.10.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"        % "2.5.2")
-addSbtPlugin("com.codecommit"    % "sbt-github-packages" % "0.5.3")
-addSbtPlugin("com.github.sbt"    % "sbt-native-packager" % "1.10.4")
 
 resolvers ++= Resolver.sonatypeOssRepos("snapshots")


### PR DESCRIPTION
This branch adds support for _ad-hoc_ queries against the `annotations` view in the database. This feature is needed to support the upcoming vars query web ui. 

The endpoints for these new features will be under `v1/query`

- [x] Add `distinct` as a flag. Default should be true.
- [x] Add `strict`(?) as a flag. Default is false. When `false` adds the `observation_uuid` and `index_recorded_timestamp` columns and sorts by those.
- [x] Add `orderby` param. This should be ignored when strict is true (verify that this is the behavior we want)
- [x] Add `equals` operator
- [x] Rename `like` to `contains` and retain current behavior
- [x] Add `like` that takes a sql like string (e.g. `http%`)
- [x] Add integration tests for sql server and postgres